### PR TITLE
feat: Add workdesk summaries integration with expanded layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,40 @@ uv run scripts/sanitize_url.py "URL_HERE"
 
 # Workflow Management
 
+## Next Journal Date Management
+
+### **Date Source**: 
+Next journal date is determined by the title in `workdesk/sources.md`:
+```
+# Sources for Journal 2025-09-07
+```
+
+### **URL Structure**:
+- **Workdesk summaries** (before publication): `/journals/2025-09-07/001/`
+- **Published summaries** (after publication): `/journals/2025-09-07/001/`
+- **URLs remain stable** throughout editorial workflow
+
+### **Editorial Workflow**:
+1. **Start new week**: Update `workdesk/sources.md` title with next journal date
+2. **Content accumulation**: Summaries accessible via `/journals/YYYY-MM-DD/xxx/`
+3. **Journal publication**: Same URLs now serve published content
+4. **No URL migration**: Links shared during development remain valid
+
+### **Summary Detail Pages**:
+- **Workdesk summaries**: Link to `/journals/[next-date]/[id]/` from homepage sidebar
+- **Journal summaries**: Link to `/journals/[date]/[id]/` from summaries pages
+- **Single route**: `src/pages/journals/[date]/[id].astro` handles both types
+- **Content detection**: Automatically serves workdesk or published content based on date
+
+### **Commands**:
+```bash
+# Check next journal date
+grep "^# Sources for Journal" workdesk/sources.md
+
+# Start new journal week (update sources.md title)
+# Manual: Edit "# Sources for Journal YYYY-MM-DD" in workdesk/sources.md
+```
+
 ## Step Execution
 - Follow workflow steps sequentially: STEP_00 → STEP_11
 - Update TodoWrite frequently to track progress

--- a/website/src/components/WorkdeskSidebar.astro
+++ b/website/src/components/WorkdeskSidebar.astro
@@ -1,0 +1,313 @@
+---
+import { getAllWorkdeskSummaries } from '@/utils/workdesk-parser';
+
+// Get all workdesk summaries
+const workdeskSummaries = getAllWorkdeskSummaries();
+
+// Helper function to format date
+function formatDate(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  
+  if (diffDays === 0) {
+    return '今日';
+  } else if (diffDays === 1) {
+    return '昨日';
+  } else if (diffDays < 7) {
+    return `${diffDays}日前`;
+  } else if (diffDays < 30) {
+    const weeks = Math.floor(diffDays / 7);
+    return `${weeks}週間前`;
+  } else {
+    return date.toLocaleDateString('ja-JP', { 
+      month: 'short', 
+      day: 'numeric' 
+    });
+  }
+}
+
+// Helper function to get domain display name
+function getDomainDisplay(domain: string): string {
+  // Remove common prefixes and show cleaner domain names
+  return domain.replace(/^www\./, '');
+}
+---
+
+<aside class="workdesk-sidebar">
+  <div class="sidebar-header">
+    <h2>ワークデスク サマリー</h2>
+    <span class="summary-count">{workdeskSummaries.length}件</span>
+  </div>
+  
+  <div class="summaries-container">
+    {workdeskSummaries.length === 0 ? (
+      <div class="no-summaries">
+        <p>ワークデスクにサマリーがありません</p>
+      </div>
+    ) : (
+      <div class="summaries-list">
+        {workdeskSummaries.map((summary) => (
+          <article class="summary-item">
+            <div class="summary-header">
+              <h3 class="summary-title">
+                <a href={summary.url} target="_blank" rel="noopener noreferrer">
+                  {summary.title}
+                </a>
+              </h3>
+              <div class="summary-meta">
+                <span class="summary-domain">{getDomainDisplay(summary.domain)}</span>
+                <time class="summary-date">{formatDate(summary.modifiedAt)}</time>
+              </div>
+            </div>
+            
+            <p class="summary-excerpt">{summary.excerpt}</p>
+            
+            {summary.scores && (
+              <div class="summary-scores">
+                {summary.scores.overall && (
+                  <span class="score overall">総合: {summary.scores.overall}/100</span>
+                )}
+                {summary.scores.signal && (
+                  <span class="score signal">シグナル: {summary.scores.signal}/5</span>
+                )}
+              </div>
+            )}
+            
+            {summary.topics && summary.topics.length > 0 && (
+              <div class="summary-topics">
+                {summary.topics.slice(0, 3).map((topic) => (
+                  <span class="topic-tag">{topic}</span>
+                ))}
+                {summary.topics.length > 3 && (
+                  <span class="topic-more">+{summary.topics.length - 3}</span>
+                )}
+              </div>
+            )}
+          </article>
+        ))}
+      </div>
+    )}
+  </div>
+</aside>
+
+<style>
+  .workdesk-sidebar {
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    height: fit-content;
+    max-height: calc(100vh - 2rem);
+    display: flex;
+    flex-direction: column;
+    position: sticky;
+    top: 2rem;
+  }
+
+  .sidebar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .sidebar-header h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0;
+  }
+
+  .summary-count {
+    background: #e0e7ff;
+    color: #3730a3;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+  }
+
+  .summaries-container {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .summaries-list {
+    overflow-y: auto;
+    flex: 1;
+    padding-right: 0.25rem;
+  }
+
+  /* Custom scrollbar */
+  .summaries-list::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  .summaries-list::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .summaries-list::-webkit-scrollbar-thumb {
+    background: #d1d5db;
+    border-radius: 2px;
+  }
+
+  .summaries-list::-webkit-scrollbar-thumb:hover {
+    background: #9ca3af;
+  }
+
+  .summary-item {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .summary-item:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+
+  .summary-header {
+    margin-bottom: 0.75rem;
+  }
+
+  .summary-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.4;
+    margin: 0 0 0.5rem 0;
+  }
+
+  .summary-title a {
+    color: #1f2937;
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .summary-title a:hover {
+    color: #2563eb;
+  }
+
+  .summary-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .summary-domain {
+    color: #2563eb;
+    font-size: 0.75rem;
+    font-weight: 500;
+    background: #eff6ff;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+  }
+
+  .summary-date {
+    color: #6b7280;
+    font-size: 0.75rem;
+  }
+
+  .summary-excerpt {
+    color: #4b5563;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    margin: 0 0 0.75rem 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .summary-scores {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .score {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+  }
+
+  .score.overall {
+    background: #f3e8ff;
+    color: #6b21a8;
+  }
+
+  .score.signal {
+    background: #ecfdf5;
+    color: #047857;
+  }
+
+  .summary-topics {
+    display: flex;
+    gap: 0.375rem;
+    flex-wrap: wrap;
+  }
+
+  .topic-tag {
+    font-size: 0.6875rem;
+    color: #374151;
+    background: #f3f4f6;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    border: 1px solid #d1d5db;
+  }
+
+  .topic-more {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    font-weight: 500;
+  }
+
+  .no-summaries {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: #6b7280;
+  }
+
+  .no-summaries p {
+    margin: 0;
+    font-size: 0.875rem;
+  }
+
+  /* Responsive design */
+  @media (max-width: 1024px) {
+    .workdesk-sidebar {
+      position: static;
+      max-height: 400px;
+      margin-top: 2rem;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .workdesk-sidebar {
+      padding: 1rem;
+      max-height: 300px;
+    }
+
+    .sidebar-header h2 {
+      font-size: 1.125rem;
+    }
+
+    .summary-title {
+      font-size: 0.8125rem;
+    }
+
+    .summary-excerpt {
+      font-size: 0.75rem;
+      -webkit-line-clamp: 2;
+    }
+  }
+</style>

--- a/website/src/components/WorkdeskSidebar.astro
+++ b/website/src/components/WorkdeskSidebar.astro
@@ -1,8 +1,11 @@
 ---
 import { getAllWorkdeskSummaries } from '@/utils/workdesk-parser';
+import { getNextJournalDate } from '@/utils/journal-date';
+import { withBase } from '@/utils/base-path';
 
-// Get all workdesk summaries
+// Get all workdesk summaries and next journal date
 const workdeskSummaries = getAllWorkdeskSummaries();
+const nextJournalDate = getNextJournalDate();
 
 // Helper function to format date
 function formatDate(date: Date): string {
@@ -51,7 +54,7 @@ function getDomainDisplay(domain: string): string {
           <article class="summary-item">
             <div class="summary-header">
               <h3 class="summary-title">
-                <a href={summary.url} target="_blank" rel="noopener noreferrer">
+                <a href={withBase(`/journals/${nextJournalDate}/${summary.id}/`)}>
                   {summary.title}
                 </a>
               </h3>
@@ -84,6 +87,15 @@ function getDomainDisplay(domain: string): string {
                 )}
               </div>
             )}
+            
+            <div class="summary-actions">
+              <a href={withBase(`/journals/${nextJournalDate}/${summary.id}/`)} class="btn btn-primary">
+                詳細を見る
+              </a>
+              <a href={summary.url} target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
+                元記事を読む
+              </a>
+            </div>
           </article>
         ))}
       </div>
@@ -269,6 +281,49 @@ function getDomainDisplay(domain: string): string {
     font-size: 0.6875rem;
     color: #6b7280;
     font-weight: 500;
+  }
+
+  .summary-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    border: 1px solid transparent;
+    text-align: center;
+    justify-content: center;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .btn-primary {
+    background-color: #2563eb;
+    color: white;
+  }
+
+  .btn-primary:hover {
+    background-color: #1d4ed8;
+    text-decoration: none;
+  }
+
+  .btn-secondary {
+    background-color: #64748b;
+    color: white;
+  }
+
+  .btn-secondary:hover {
+    background-color: #475569;
+    text-decoration: none;
   }
 
   .no-summaries {

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -128,7 +128,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   }
 
   .nav-container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 var(--spacing-md);
     display: flex;
@@ -162,7 +162,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   /* Main content */
   .main-content {
     flex: 1;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: var(--spacing-2xl) var(--spacing-md);
     width: 100%;
@@ -177,7 +177,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   }
 
   .footer-container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 var(--spacing-md);
     text-align: center;

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import WeeklyJournalCard from '@/components/WeeklyJournalCard.astro';
+import WorkdeskSidebar from '@/components/WorkdeskSidebar.astro';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import { withBase } from '@/utils/base-path';
 import { getAllJournalDates, getLatestJournal } from '@/utils/content-parser';
@@ -14,43 +15,85 @@ const allDates = getAllJournalDates();
 ---
 
 <BaseLayout title={title} description={description}>
-  <div class="hero-section">
-    <h1 class="hero-title">GenAI週刊</h1>
-    <p class="hero-subtitle">AI・コーディング関連の週刊ジャーナル</p>
-    <p class="hero-description">
-      AI開発ツールとコーディングの最新動向を厳選してお届けします。
-      毎週、技術の本質を見極めた記事とユニークな視点の情報をキュレーションしています。
-    </p>
+  <div class="homepage-container">
+    <div class="main-content">
+      <div class="hero-section">
+        <h1 class="hero-title">GenAI週刊</h1>
+        <p class="hero-subtitle">AI・コーディング関連の週刊ジャーナル</p>
+        <p class="hero-description">
+          AI開発ツールとコーディングの最新動向を厳選してお届けします。
+          毎週、技術の本質を見極めた記事とユニークな視点の情報をキュレーションしています。
+        </p>
+      </div>
+
+      <section class="latest-section">
+        <h2>最新号</h2>
+        {latestJournal ? (
+          <div class="weekly-journal-container">
+            <WeeklyJournalCard journalData={latestJournal} />
+          </div>
+        ) : (
+          <div class="no-content">
+            <p>最新のジャーナルを読み込めませんでした。</p>
+            <p>ジャーナルデータが正しく配置されているか確認してください。</p>
+          </div>
+        )}
+      </section>
+
+      <section class="archive-section">
+        <h2>アーカイブ</h2>
+        <p>過去のジャーナルをすべて閲覧できます。</p>
+        {allDates.length > 0 && (
+          <div class="archive-stats">
+            <p><strong>{allDates.length}</strong>週分のジャーナルが利用可能です</p>
+            <p>最新: {allDates[0]} / 最古: {allDates[allDates.length - 1]}</p>
+          </div>
+        )}
+        <a href={withBase('/archive/')} class="btn btn-primary">アーカイブを見る</a>
+      </section>
+    </div>
+
+    <div class="sidebar-content">
+      <WorkdeskSidebar />
+    </div>
   </div>
-
-  <section class="latest-section">
-    <h2>最新号</h2>
-    {latestJournal ? (
-      <div class="weekly-journal-container">
-        <WeeklyJournalCard journalData={latestJournal} />
-      </div>
-    ) : (
-      <div class="no-content">
-        <p>最新のジャーナルを読み込めませんでした。</p>
-        <p>ジャーナルデータが正しく配置されているか確認してください。</p>
-      </div>
-    )}
-  </section>
-
-  <section class="archive-section">
-    <h2>アーカイブ</h2>
-    <p>過去のジャーナルをすべて閲覧できます。</p>
-    {allDates.length > 0 && (
-      <div class="archive-stats">
-        <p><strong>{allDates.length}</strong>週分のジャーナルが利用可能です</p>
-        <p>最新: {allDates[0]} / 最古: {allDates[allDates.length - 1]}</p>
-      </div>
-    )}
-    <a href={withBase('/archive/')} class="btn btn-primary">アーカイブを見る</a>
-  </section>
 </BaseLayout>
 
 <style>
+  /* Homepage Container Layout */
+  .homepage-container {
+    display: grid;
+    grid-template-columns: 1fr 420px;
+    gap: 3rem;
+    align-items: start;
+  }
+
+  .main-content {
+    min-width: 0; /* Prevents grid overflow */
+  }
+
+  .sidebar-content {
+    /* Sidebar styling handled in WorkdeskSidebar component */
+  }
+
+  /* Responsive layout */
+  @media (max-width: 1200px) {
+    .homepage-container {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+    }
+
+    .sidebar-content {
+      order: 2;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .homepage-container {
+      gap: 1.5rem;
+    }
+  }
+
   .hero-section {
     text-align: center;
     padding: 3rem 0 4rem;

--- a/website/src/pages/journals/[date]/[id].astro
+++ b/website/src/pages/journals/[date]/[id].astro
@@ -70,7 +70,7 @@ if (isNextJournalDate(date)) {
     summary = {
       id: workdeskSummary.id,
       title: workdeskSummary.title,
-      content: sanitizeContent(workdeskSummary.topics?.join('\n\n') || ''),
+      content: sanitizeContent(workdeskSummary.fullContent || ''),
       excerpt: workdeskSummary.excerpt,
       sourceUrl: workdeskSummary.url,
       domain: workdeskSummary.domain,

--- a/website/src/pages/journals/[date]/[id].astro
+++ b/website/src/pages/journals/[date]/[id].astro
@@ -130,176 +130,183 @@ const nextSummary = currentIndex >= 0 && currentIndex < (isWorkdeskSummary ? all
 ---
 
 <BaseLayout title={title} description={description}>
-  <article class="summary-detail">
-    <header class="summary-header">
-      <nav class="breadcrumb">
-        <a href={withBase('/')}>ホーム</a>
-        <span class="separator">›</span>
-        {isWorkdeskSummary ? (
-          <>
-            <a href={withBase('/')}>ワークデスク</a>
-            <span class="separator">›</span>
-            <span class="current">{summary.title}</span>
-          </>
-        ) : (
-          <>
-            <a href={withBase('/archive/')}>アーカイブ</a>
-            <span class="separator">›</span>
-            <a href={withBase(`/journals/${date}/`)}>{displayDate}号</a>
-            <span class="separator">›</span>
-            <span class="current">{summary.title}</span>
-          </>
+  <div class="summary-detail-container">
+    <article class="summary-detail">
+      <header class="summary-header">
+        <nav class="breadcrumb">
+          <a href={withBase('/')}>ホーム</a>
+          <span class="separator">›</span>
+          {isWorkdeskSummary ? (
+            <>
+              <a href={withBase('/')}>ワークデスク</a>
+              <span class="separator">›</span>
+              <span class="current">{summary.title}</span>
+            </>
+          ) : (
+            <>
+              <a href={withBase('/archive/')}>アーカイブ</a>
+              <span class="separator">›</span>
+              <a href={withBase(`/journals/${date}/`)}>{displayDate}号</a>
+              <span class="separator">›</span>
+              <span class="current">{summary.title}</span>
+            </>
+          )}
+        </nav>
+
+        <div class="summary-meta">
+          <div class="status-badge" class:list={[`status-${status}`]}>
+            {statusLabel}
+          </div>
+          <div class="summary-info">
+            <span class="summary-id">#{summary.id}</span>
+            <span class="summary-stats">{summary.wordCount.toLocaleString()}文字 • {summary.readingTime}分</span>
+          </div>
+        </div>
+
+        <h1 class="summary-title">{summary.title}</h1>
+
+        <div class="source-info">
+          <div class="domain-badge">
+            <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer">
+              {summary.domain}
+            </a>
+          </div>
+          {isWorkdeskSummary && 'modifiedAt' in summary && (
+            <time class="modified-date">
+              更新: {new Date(summary.modifiedAt).toLocaleDateString('ja-JP')}
+            </time>
+          )}
+        </div>
+
+        {!isWorkdeskSummary && journalContext && (
+          <div class="journal-context">
+            <h3>掲載情報</h3>
+            <div class="context-info">
+              <span class="journal-issue">
+                <a href={withBase(`/journals/${date}/`)}>
+                  {displayDate}号
+                </a>
+              </span>
+              <span class="journal-section" class:list={[`section-${summary.status}`]}>
+                {summary.status === 'main' && 'メインジャーナル掲載'}
+                {summary.status === 'annex' && 'アネックス掲載'}
+                {summary.status === 'omitted' && '未掲載'}
+              </span>
+            </div>
+          </div>
+        )}
+      </header>
+
+      <main class="summary-content">
+        <div class="content-excerpt">
+          <h2>概要</h2>
+          <p>{summary.excerpt}</p>
+        </div>
+
+        <div class="content-body">
+          <h2>詳細内容</h2>
+          <div class="content-text">
+            <markdown-renderer>{summary.content}</markdown-renderer>
+          </div>
+        </div>
+
+        <div class="actions-section">
+          <a 
+            href={summary.sourceUrl} 
+            target="_blank" 
+            rel="noopener noreferrer" 
+            class="btn btn-primary"
+          >
+            元記事を読む
+          </a>
+          {!isWorkdeskSummary && journalContext && (
+            <a 
+              href={withBase(`/journals/${date}/summaries/`)} 
+              class="btn btn-outline"
+            >
+              他のサマリーを見る
+            </a>
+          )}
+        </div>
+      </main>
+
+      <nav class="summary-navigation">
+        {prevSummary && (
+          <a href={withBase(`/journals/${date}/${prevSummary.id}/`)} class="nav-link nav-prev">
+            <div class="nav-direction">← 前のサマリー</div>
+            <div class="nav-title">{prevSummary.title}</div>
+          </a>
+        )}
+        {nextSummary && (
+          <a href={withBase(`/journals/${date}/${nextSummary.id}/`)} class="nav-link nav-next">
+            <div class="nav-direction">次のサマリー →</div>
+            <div class="nav-title">{nextSummary.title}</div>
+          </a>
         )}
       </nav>
 
-      <div class="summary-meta">
-        <div class="status-badge" class:list={[`status-${status}`]}>
-          {statusLabel}
+      <footer class="summary-footer">
+        <div class="footer-actions">
+          {isWorkdeskSummary ? (
+            <a href={withBase('/')} class="btn btn-outline">← ホームに戻る</a>
+          ) : (
+            <>
+              <a href={withBase(`/journals/${date}/`)} class="btn btn-outline">← {displayDate}号の概要</a>
+              <a href={withBase('/archive/')} class="btn btn-outline">アーカイブ一覧</a>
+            </>
+          )}
         </div>
-        <div class="summary-info">
-          <span class="summary-id">#{summary.id}</span>
-          <span class="summary-stats">{summary.wordCount.toLocaleString()}文字 • {summary.readingTime}分</span>
-        </div>
-      </div>
+      </footer>
+    </article>
 
-      <h1 class="summary-title">{summary.title}</h1>
-
-      <div class="source-info">
-        <div class="domain-badge">
-          <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer">
-            {summary.domain}
-          </a>
-        </div>
-        {isWorkdeskSummary && 'modifiedAt' in summary && (
-          <time class="modified-date">
-            更新: {new Date(summary.modifiedAt).toLocaleDateString('ja-JP')}
-          </time>
-        )}
-      </div>
-
-      {!isWorkdeskSummary && journalContext && (
-        <div class="journal-context">
-          <h3>掲載情報</h3>
-          <div class="context-info">
-            <span class="journal-issue">
-              <a href={withBase(`/journals/${date}/`)}>
-                {displayDate}号
-              </a>
-            </span>
-            <span class="journal-section" class:list={[`section-${summary.status}`]}>
-              {summary.status === 'main' && 'メインジャーナル掲載'}
-              {summary.status === 'annex' && 'アネックス掲載'}
-              {summary.status === 'omitted' && '未掲載'}
-            </span>
+    {/* Metadata sidebar for workdesk summaries */}
+    {isWorkdeskSummary && (
+      <aside class="summary-metadata">
+        {'scores' in summary && summary.scores && (
+          <div class="scores-section">
+            <h3>評価スコア</h3>
+            <div class="scores-grid">
+              {summary.scores.overall && (
+                <div class="score-item overall">
+                  <span class="score-label">総合</span>
+                  <span class="score-value">{summary.scores.overall}/100</span>
+                </div>
+              )}
+              {summary.scores.signal && (
+                <div class="score-item">
+                  <span class="score-label">シグナル</span>
+                  <span class="score-value">{summary.scores.signal}/5</span>
+                </div>
+              )}
+              {summary.scores.depth && (
+                <div class="score-item">
+                  <span class="score-label">深度</span>
+                  <span class="score-value">{summary.scores.depth}/5</span>
+                </div>
+              )}
+              {summary.scores.unique && (
+                <div class="score-item">
+                  <span class="score-label">独自性</span>
+                  <span class="score-value">{summary.scores.unique}/5</span>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
-
-      {isWorkdeskSummary && 'scores' in summary && summary.scores && (
-        <div class="scores-section">
-          <h3>評価スコア</h3>
-          <div class="scores-grid">
-            {summary.scores.overall && (
-              <div class="score-item overall">
-                <span class="score-label">総合</span>
-                <span class="score-value">{summary.scores.overall}/100</span>
-              </div>
-            )}
-            {summary.scores.signal && (
-              <div class="score-item">
-                <span class="score-label">シグナル</span>
-                <span class="score-value">{summary.scores.signal}/5</span>
-              </div>
-            )}
-            {summary.scores.depth && (
-              <div class="score-item">
-                <span class="score-label">深度</span>
-                <span class="score-value">{summary.scores.depth}/5</span>
-              </div>
-            )}
-            {summary.scores.unique && (
-              <div class="score-item">
-                <span class="score-label">独自性</span>
-                <span class="score-value">{summary.scores.unique}/5</span>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
-      {isWorkdeskSummary && 'topics' in summary && summary.topics && summary.topics.length > 0 && (
-        <div class="topics-section">
-          <h3>関連トピック</h3>
-          <div class="topics-list">
-            {summary.topics.map(topic => (
-              <span class="topic-tag">{topic}</span>
-            ))}
-          </div>
-        </div>
-      )}
-    </header>
-
-    <main class="summary-content">
-      <div class="content-excerpt">
-        <h2>概要</h2>
-        <p>{summary.excerpt}</p>
-      </div>
-
-      <div class="content-body">
-        <h2>詳細内容</h2>
-        <div class="content-text">
-          <markdown-renderer>{summary.content}</markdown-renderer>
-        </div>
-      </div>
-
-      <div class="actions-section">
-        <a 
-          href={summary.sourceUrl} 
-          target="_blank" 
-          rel="noopener noreferrer" 
-          class="btn btn-primary"
-        >
-          元記事を読む
-        </a>
-        {!isWorkdeskSummary && journalContext && (
-          <a 
-            href={withBase(`/journals/${date}/summaries/`)} 
-            class="btn btn-outline"
-          >
-            他のサマリーを見る
-          </a>
         )}
-      </div>
-    </main>
 
-    <nav class="summary-navigation">
-      {prevSummary && (
-        <a href={withBase(`/journals/${date}/${prevSummary.id}/`)} class="nav-link nav-prev">
-          <div class="nav-direction">← 前のサマリー</div>
-          <div class="nav-title">{prevSummary.title}</div>
-        </a>
-      )}
-      {nextSummary && (
-        <a href={withBase(`/journals/${date}/${nextSummary.id}/`)} class="nav-link nav-next">
-          <div class="nav-direction">次のサマリー →</div>
-          <div class="nav-title">{nextSummary.title}</div>
-        </a>
-      )}
-    </nav>
-
-    <footer class="summary-footer">
-      <div class="footer-actions">
-        {isWorkdeskSummary ? (
-          <a href={withBase('/')} class="btn btn-outline">← ホームに戻る</a>
-        ) : (
-          <>
-            <a href={withBase(`/journals/${date}/`)} class="btn btn-outline">← {displayDate}号の概要</a>
-            <a href={withBase('/archive/')} class="btn btn-outline">アーカイブ一覧</a>
-          </>
+        {'topics' in summary && summary.topics && summary.topics.length > 0 && (
+          <div class="topics-section">
+            <h3>関連トピック</h3>
+            <div class="topics-list">
+              {summary.topics.map(topic => (
+                <span class="topic-tag">{topic}</span>
+              ))}
+            </div>
+          </div>
         )}
-      </div>
-    </footer>
-  </article>
+      </aside>
+    )}
+  </div>
 </BaseLayout>
 
 <script type="module" is:inline>
@@ -359,10 +366,24 @@ const nextSummary = currentIndex >= 0 && currentIndex < (isWorkdeskSummary ? all
 </script>
 
 <style>
-  .summary-detail {
-    max-width: 800px;
+  .summary-detail-container {
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 2rem 0;
+    padding: 2rem;
+    display: grid;
+    grid-template-columns: 1fr 320px;
+    gap: 3rem;
+    align-items: start;
+  }
+
+  .summary-detail {
+    min-width: 0; /* Prevent grid overflow */
+  }
+
+  .summary-metadata {
+    position: sticky;
+    top: 2rem;
+    height: fit-content;
   }
 
   /* Header styles */
@@ -469,9 +490,7 @@ const nextSummary = currentIndex >= 0 && currentIndex < (isWorkdeskSummary ? all
   }
 
   /* Context sections */
-  .journal-context,
-  .scores-section,
-  .topics-section {
+  .journal-context {
     background: #f8fafc;
     border: 1px solid #e2e8f0;
     border-radius: 0.75rem;
@@ -479,13 +498,36 @@ const nextSummary = currentIndex >= 0 && currentIndex < (isWorkdeskSummary ? all
     margin-bottom: 2rem;
   }
 
-  .journal-context h3,
-  .scores-section h3,
-  .topics-section h3 {
+  .journal-context h3 {
     font-size: 1.125rem;
     font-weight: 600;
     color: #374151;
     margin: 0 0 1rem 0;
+  }
+
+  /* Sidebar metadata sections */
+  .summary-metadata .scores-section,
+  .summary-metadata .topics-section {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .summary-metadata .scores-section:last-child,
+  .summary-metadata .topics-section:last-child {
+    margin-bottom: 0;
+  }
+
+  .summary-metadata h3 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #374151;
+    margin: 0 0 1rem 0;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #e5e7eb;
   }
 
   .context-info {
@@ -718,8 +760,30 @@ const nextSummary = currentIndex >= 0 && currentIndex < (isWorkdeskSummary ? all
   }
 
   /* Responsive design */
+  @media (max-width: 1024px) {
+    .summary-detail-container {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+      max-width: 800px;
+    }
+
+    .summary-metadata {
+      position: static;
+      order: -1; /* Show metadata before main content on mobile */
+    }
+
+    .summary-metadata .scores-section,
+    .summary-metadata .topics-section {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+  }
+
   @media (max-width: 768px) {
-    .summary-detail {
+    .summary-detail-container {
       padding: 1rem;
     }
 

--- a/website/src/pages/journals/[date]/[id].astro
+++ b/website/src/pages/journals/[date]/[id].astro
@@ -1,0 +1,752 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import { withBase } from '@/utils/base-path';
+import { getAllJournalDates, parseJournalByDate } from '@/utils/content-parser';
+import { getAllWorkdeskSummaries } from '@/utils/workdesk-parser';
+import { getNextJournalDate, isNextJournalDate, getJournalStatusLabel, formatJapaneseDateDisplay } from '@/utils/journal-date';
+import '@/styles/global.css';
+import DOMPurify from 'dompurify';
+import { JSDOM } from 'jsdom';
+
+export async function getStaticPaths() {
+  const paths: Array<{params: {date: string; id: string}}> = [];
+
+  // Generate paths for published journal summaries
+  const journalDates = getAllJournalDates();
+  for (const date of journalDates) {
+    const journalData = parseJournalByDate(date);
+    if (journalData) {
+      journalData.summaries.forEach(summary => {
+        paths.push({
+          params: { date, id: summary.id }
+        });
+      });
+    }
+  }
+
+  // Generate paths for workdesk summaries (next journal issue)
+  try {
+    const nextDate = getNextJournalDate();
+    const workdeskSummaries = getAllWorkdeskSummaries();
+    
+    workdeskSummaries.forEach(summary => {
+      paths.push({
+        params: { date: nextDate, id: summary.id }
+      });
+    });
+  } catch (error) {
+    console.warn('Failed to generate workdesk summary paths:', error);
+  }
+
+  return paths;
+}
+
+const { date, id } = Astro.params;
+
+if (!date || !id || typeof date !== 'string' || typeof id !== 'string') {
+  throw new Error('Invalid date or id parameter');
+}
+
+// Server-side sanitization
+const window = new JSDOM('').window;
+const purify = DOMPurify(window);
+
+function sanitizeContent(content: string): string {
+  return purify.sanitize(content);
+}
+
+let summary;
+let journalContext;
+let isWorkdeskSummary = false;
+let status: 'published' | 'draft' = 'published'; // Default to published
+
+// Determine if this is a workdesk (next journal) or published journal summary
+if (isNextJournalDate(date)) {
+  // Handle workdesk summary for next journal issue
+  const workdeskSummaries = getAllWorkdeskSummaries();
+  const workdeskSummary = workdeskSummaries.find(s => s.id === id);
+  
+  if (workdeskSummary) {
+    summary = {
+      id: workdeskSummary.id,
+      title: workdeskSummary.title,
+      content: sanitizeContent(workdeskSummary.topics?.join('\n\n') || ''),
+      excerpt: workdeskSummary.excerpt,
+      sourceUrl: workdeskSummary.url,
+      domain: workdeskSummary.domain,
+      wordCount: workdeskSummary.wordCount,
+      readingTime: Math.max(1, Math.ceil(workdeskSummary.wordCount / 200)),
+      slug: workdeskSummary.filename.replace('.md', ''),
+      date: date,
+      filename: workdeskSummary.filename,
+      status: 'omitted' as const,
+      modifiedAt: workdeskSummary.modifiedAt,
+      scores: workdeskSummary.scores,
+      topics: workdeskSummary.topics
+    };
+    isWorkdeskSummary = true;
+    status = 'draft';
+    journalContext = null;
+  }
+} else {
+  // Handle published journal summary
+  const journalData = parseJournalByDate(date);
+  if (journalData) {
+    const journalSummary = journalData.summaries.find(s => s.id === id);
+    if (journalSummary) {
+      summary = {
+        ...journalSummary,
+        content: sanitizeContent(journalSummary.content)
+      };
+      status = 'published';
+      journalContext = journalData;
+    }
+  }
+}
+
+if (!summary) {
+  throw new Error(`Summary not found: ${date}/${id}`);
+}
+
+// Page metadata
+const displayDate = formatJapaneseDateDisplay(date);
+const statusLabel = getJournalStatusLabel(date);
+const title = `${summary.title} - GenAI週刊`;
+const description = summary.excerpt;
+
+// Navigation data
+const allWorkdeskSummaries = isWorkdeskSummary ? getAllWorkdeskSummaries() : [];
+const currentIndex = isWorkdeskSummary 
+  ? allWorkdeskSummaries.findIndex(s => s.id === id)
+  : journalContext?.summaries.findIndex(s => s.id === id) ?? -1;
+
+const prevSummary = currentIndex > 0 
+  ? (isWorkdeskSummary ? allWorkdeskSummaries[currentIndex - 1] : journalContext?.summaries[currentIndex - 1])
+  : null;
+
+const nextSummary = currentIndex >= 0 && currentIndex < (isWorkdeskSummary ? allWorkdeskSummaries.length - 1 : (journalContext?.summaries.length ?? 0) - 1)
+  ? (isWorkdeskSummary ? allWorkdeskSummaries[currentIndex + 1] : journalContext?.summaries[currentIndex + 1])
+  : null;
+---
+
+<BaseLayout title={title} description={description}>
+  <article class="summary-detail">
+    <header class="summary-header">
+      <nav class="breadcrumb">
+        <a href={withBase('/')}>ホーム</a>
+        <span class="separator">›</span>
+        {isWorkdeskSummary ? (
+          <>
+            <a href={withBase('/')}>ワークデスク</a>
+            <span class="separator">›</span>
+            <span class="current">{summary.title}</span>
+          </>
+        ) : (
+          <>
+            <a href={withBase('/archive/')}>アーカイブ</a>
+            <span class="separator">›</span>
+            <a href={withBase(`/journals/${date}/`)}>{displayDate}号</a>
+            <span class="separator">›</span>
+            <span class="current">{summary.title}</span>
+          </>
+        )}
+      </nav>
+
+      <div class="summary-meta">
+        <div class="status-badge" class:list={[`status-${status}`]}>
+          {statusLabel}
+        </div>
+        <div class="summary-info">
+          <span class="summary-id">#{summary.id}</span>
+          <span class="summary-stats">{summary.wordCount.toLocaleString()}文字 • {summary.readingTime}分</span>
+        </div>
+      </div>
+
+      <h1 class="summary-title">{summary.title}</h1>
+
+      <div class="source-info">
+        <div class="domain-badge">
+          <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer">
+            {summary.domain}
+          </a>
+        </div>
+        {isWorkdeskSummary && 'modifiedAt' in summary && (
+          <time class="modified-date">
+            更新: {new Date(summary.modifiedAt).toLocaleDateString('ja-JP')}
+          </time>
+        )}
+      </div>
+
+      {!isWorkdeskSummary && journalContext && (
+        <div class="journal-context">
+          <h3>掲載情報</h3>
+          <div class="context-info">
+            <span class="journal-issue">
+              <a href={withBase(`/journals/${date}/`)}>
+                {displayDate}号
+              </a>
+            </span>
+            <span class="journal-section" class:list={[`section-${summary.status}`]}>
+              {summary.status === 'main' && 'メインジャーナル掲載'}
+              {summary.status === 'annex' && 'アネックス掲載'}
+              {summary.status === 'omitted' && '未掲載'}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {isWorkdeskSummary && 'scores' in summary && summary.scores && (
+        <div class="scores-section">
+          <h3>評価スコア</h3>
+          <div class="scores-grid">
+            {summary.scores.overall && (
+              <div class="score-item overall">
+                <span class="score-label">総合</span>
+                <span class="score-value">{summary.scores.overall}/100</span>
+              </div>
+            )}
+            {summary.scores.signal && (
+              <div class="score-item">
+                <span class="score-label">シグナル</span>
+                <span class="score-value">{summary.scores.signal}/5</span>
+              </div>
+            )}
+            {summary.scores.depth && (
+              <div class="score-item">
+                <span class="score-label">深度</span>
+                <span class="score-value">{summary.scores.depth}/5</span>
+              </div>
+            )}
+            {summary.scores.unique && (
+              <div class="score-item">
+                <span class="score-label">独自性</span>
+                <span class="score-value">{summary.scores.unique}/5</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {isWorkdeskSummary && 'topics' in summary && summary.topics && summary.topics.length > 0 && (
+        <div class="topics-section">
+          <h3>関連トピック</h3>
+          <div class="topics-list">
+            {summary.topics.map(topic => (
+              <span class="topic-tag">{topic}</span>
+            ))}
+          </div>
+        </div>
+      )}
+    </header>
+
+    <main class="summary-content">
+      <div class="content-excerpt">
+        <h2>概要</h2>
+        <p>{summary.excerpt}</p>
+      </div>
+
+      <div class="content-body">
+        <h2>詳細内容</h2>
+        <div class="content-text">
+          <markdown-renderer>{summary.content}</markdown-renderer>
+        </div>
+      </div>
+
+      <div class="actions-section">
+        <a 
+          href={summary.sourceUrl} 
+          target="_blank" 
+          rel="noopener noreferrer" 
+          class="btn btn-primary"
+        >
+          元記事を読む
+        </a>
+        {!isWorkdeskSummary && journalContext && (
+          <a 
+            href={withBase(`/journals/${date}/summaries/`)} 
+            class="btn btn-outline"
+          >
+            他のサマリーを見る
+          </a>
+        )}
+      </div>
+    </main>
+
+    <nav class="summary-navigation">
+      {prevSummary && (
+        <a href={withBase(`/journals/${date}/${prevSummary.id}/`)} class="nav-link nav-prev">
+          <div class="nav-direction">← 前のサマリー</div>
+          <div class="nav-title">{prevSummary.title}</div>
+        </a>
+      )}
+      {nextSummary && (
+        <a href={withBase(`/journals/${date}/${nextSummary.id}/`)} class="nav-link nav-next">
+          <div class="nav-direction">次のサマリー →</div>
+          <div class="nav-title">{nextSummary.title}</div>
+        </a>
+      )}
+    </nav>
+
+    <footer class="summary-footer">
+      <div class="footer-actions">
+        {isWorkdeskSummary ? (
+          <a href={withBase('/')} class="btn btn-outline">← ホームに戻る</a>
+        ) : (
+          <>
+            <a href={withBase(`/journals/${date}/`)} class="btn btn-outline">← {displayDate}号の概要</a>
+            <a href={withBase('/archive/')} class="btn btn-outline">アーカイブ一覧</a>
+          </>
+        )}
+      </div>
+    </footer>
+  </article>
+</BaseLayout>
+
+<script type="module" is:inline>
+  // Load web components for markdown rendering
+  async function initializeComponents() {
+    try {
+      const webComponentsUrl = '../../../js/web-components.js';
+      
+      try {
+        const module = await import(webComponentsUrl);
+        if (module.registerMarkdownRenderer) {
+          module.registerMarkdownRenderer();
+        } else if (window.WebComponents?.registerMarkdownRenderer) {
+          window.WebComponents.registerMarkdownRenderer();
+        }
+        console.log('✅ Markdown renderer registered successfully');
+      } catch (moduleError) {
+        console.warn('Module import failed, trying global approach:', moduleError);
+        
+        if (window.WebComponents?.registerMarkdownRenderer) {
+          window.WebComponents.registerMarkdownRenderer();
+          console.log('✅ Markdown renderer registered via global');
+        } else {
+          const script = document.createElement('script');
+          script.src = webComponentsUrl;
+          script.type = 'module';
+          
+          script.onload = () => {
+            if (window.WebComponents?.registerMarkdownRenderer) {
+              window.WebComponents.registerMarkdownRenderer();
+              console.log('✅ Markdown renderer registered via script load');
+            }
+          };
+          
+          document.head.appendChild(script);
+        }
+      }
+    } catch (error) {
+      console.warn('⚠️ Web components failed to load:', error);
+      
+      // Fallback for markdown-renderer elements
+      const markdownElements = document.querySelectorAll('markdown-renderer');
+      markdownElements.forEach(element => {
+        const content = element.textContent || '';
+        if (content.trim()) {
+          element.innerHTML = `<div class="markdown-fallback">${content}</div>`;
+        }
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeComponents);
+  } else {
+    initializeComponents();
+  }
+</script>
+
+<style>
+  .summary-detail {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 0;
+  }
+
+  /* Header styles */
+  .summary-header {
+    margin-bottom: 3rem;
+  }
+
+  .breadcrumb {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin-bottom: 1.5rem;
+  }
+
+  .breadcrumb a {
+    color: #2563eb;
+    text-decoration: none;
+  }
+
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+
+  .separator {
+    margin: 0 0.5rem;
+    color: #9ca3af;
+  }
+
+  .current {
+    color: #374151;
+    font-weight: 500;
+  }
+
+  .summary-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .status-badge {
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .status-published {
+    background: #dbeafe;
+    color: #1e40af;
+  }
+
+  .status-draft {
+    background: #fef3c7;
+    color: #92400e;
+  }
+
+  .summary-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.875rem;
+    color: #6b7280;
+  }
+
+  .summary-id {
+    font-weight: 600;
+  }
+
+  .summary-title {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1f2937;
+    line-height: 1.3;
+    margin-bottom: 1.5rem;
+  }
+
+  .source-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 2rem;
+    flex-wrap: wrap;
+  }
+
+  .domain-badge a {
+    background: #eff6ff;
+    color: #2563eb;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.875rem;
+  }
+
+  .domain-badge a:hover {
+    background: #dbeafe;
+  }
+
+  .modified-date {
+    color: #6b7280;
+    font-size: 0.875rem;
+  }
+
+  /* Context sections */
+  .journal-context,
+  .scores-section,
+  .topics-section {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .journal-context h3,
+  .scores-section h3,
+  .topics-section h3 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #374151;
+    margin: 0 0 1rem 0;
+  }
+
+  .context-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .journal-issue a {
+    color: #2563eb;
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .journal-section {
+    padding: 0.25rem 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .section-main {
+    background: #dbeafe;
+    color: #1e40af;
+  }
+
+  .section-annex {
+    background: #fef3c7;
+    color: #92400e;
+  }
+
+  .section-omitted {
+    background: #f3f4f6;
+    color: #6b7280;
+  }
+
+  .scores-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+  }
+
+  .score-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1rem;
+    background: white;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+  }
+
+  .score-item.overall {
+    border-color: #8b5cf6;
+    background: #faf5ff;
+  }
+
+  .score-label {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin-bottom: 0.5rem;
+  }
+
+  .score-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #1f2937;
+  }
+
+  .overall .score-value {
+    color: #8b5cf6;
+  }
+
+  .topics-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .topic-tag {
+    background: white;
+    color: #374151;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid #d1d5db;
+    font-size: 0.875rem;
+  }
+
+  /* Content styles */
+  .summary-content {
+    margin-bottom: 3rem;
+  }
+
+  .content-excerpt,
+  .content-body {
+    margin-bottom: 2rem;
+  }
+
+  .content-excerpt h2,
+  .content-body h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid #e5e7eb;
+  }
+
+  .content-excerpt p {
+    font-size: 1.125rem;
+    line-height: 1.7;
+    color: #374151;
+  }
+
+  .content-text {
+    line-height: 1.7;
+    color: #374151;
+  }
+
+  .markdown-fallback {
+    padding: 1rem;
+    background-color: #f8fafc;
+    border-left: 4px solid #e5e7eb;
+    border-radius: 0.5rem;
+    white-space: pre-wrap;
+  }
+
+  .actions-section {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin: 2rem 0;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    border: 1px solid transparent;
+    text-align: center;
+    justify-content: center;
+  }
+
+  .btn-primary {
+    background-color: #2563eb;
+    color: white;
+  }
+
+  .btn-primary:hover {
+    background-color: #1d4ed8;
+    text-decoration: none;
+  }
+
+  .btn-outline {
+    background-color: transparent;
+    color: #2563eb;
+    border: 1px solid #2563eb;
+  }
+
+  .btn-outline:hover {
+    background-color: #2563eb;
+    color: white;
+    text-decoration: none;
+  }
+
+  /* Navigation styles */
+  .summary-navigation {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .nav-link {
+    display: block;
+    padding: 1rem;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    text-decoration: none;
+    transition: all 0.2s ease;
+  }
+
+  .nav-link:hover {
+    border-color: #d1d5db;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    text-decoration: none;
+  }
+
+  .nav-prev {
+    text-align: left;
+  }
+
+  .nav-next {
+    text-align: right;
+  }
+
+  .nav-direction {
+    font-size: 0.875rem;
+    color: #6b7280;
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+  }
+
+  .nav-title {
+    color: #1f2937;
+    font-weight: 500;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .summary-footer {
+    padding-top: 2rem;
+    border-top: 1px solid #e5e7eb;
+  }
+
+  .footer-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  /* Responsive design */
+  @media (max-width: 768px) {
+    .summary-detail {
+      padding: 1rem;
+    }
+
+    .summary-title {
+      font-size: 1.5rem;
+    }
+
+    .summary-meta {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .source-info {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .scores-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    .summary-navigation {
+      grid-template-columns: 1fr;
+    }
+
+    .footer-actions {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/website/src/pages/journals/[date]/summaries.astro
+++ b/website/src/pages/journals/[date]/summaries.astro
@@ -171,18 +171,13 @@ const summariesByStatus = {
                 </div>
 
                 <footer class="summary-actions">
-                  <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer" class="btn btn-primary">
+                  <a href={withBase(`/journals/${date}/${summary.id}/`)} class="btn btn-primary">
+                    詳細ページへ
+                  </a>
+                  <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer" class="btn btn-outline">
                     元記事を読む
                   </a>
-                  <button class="btn btn-outline toggle-content" data-summary-id={summary.id}>
-                    詳細を見る
-                  </button>
                 </footer>
-
-                <div class="summary-full-content" id={`content-${summary.id}`} style="display: none;">
-                  <div class="content-divider"></div>
-                  <markdown-renderer class="full-content-text">{summary.content}</markdown-renderer>
-                </div>
               </article>
             ))}
           </div>
@@ -232,18 +227,13 @@ const summariesByStatus = {
                 </div>
 
                 <footer class="summary-actions">
-                  <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer" class="btn btn-primary">
+                  <a href={withBase(`/journals/${date}/${summary.id}/`)} class="btn btn-primary">
+                    詳細ページへ
+                  </a>
+                  <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer" class="btn btn-outline">
                     元記事を読む
                   </a>
-                  <button class="btn btn-outline toggle-content" data-summary-id={summary.id}>
-                    詳細を見る
-                  </button>
                 </footer>
-
-                <div class="summary-full-content" id={`content-${summary.id}`} style="display: none;">
-                  <div class="content-divider"></div>
-                  <markdown-renderer class="full-content-text">{summary.content}</markdown-renderer>
-                </div>
               </article>
             ))}
           </div>
@@ -288,18 +278,13 @@ const summariesByStatus = {
                 </div>
 
                 <footer class="summary-actions">
-                  <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer" class="btn btn-primary">
+                  <a href={withBase(`/journals/${date}/${summary.id}/`)} class="btn btn-primary">
+                    詳細ページへ
+                  </a>
+                  <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer" class="btn btn-outline">
                     元記事を読む
                   </a>
-                  <button class="btn btn-outline toggle-content" data-summary-id={summary.id}>
-                    詳細を見る
-                  </button>
                 </footer>
-
-                <div class="summary-full-content" id={`content-${summary.id}`} style="display: none;">
-                  <div class="content-divider"></div>
-                  <markdown-renderer class="full-content-text">{summary.content}</markdown-renderer>
-                </div>
               </article>
             ))}
           </div>
@@ -324,34 +309,8 @@ const summariesByStatus = {
 </BaseLayout>
 
 
-<script is:inline>
-  // Toggle summary content visibility
-  document.addEventListener('DOMContentLoaded', function() {
-    var toggleButtons = document.querySelectorAll('.toggle-content');
 
-    toggleButtons.forEach(function(button) {
-      button.addEventListener('click', function() {
-        var summaryId = button.getAttribute('data-summary-id');
-        var contentDiv = document.getElementById('content-' + summaryId);
-
-        if (contentDiv) {
-          var isVisible = contentDiv.style.display !== 'none';
-
-          if (isVisible) {
-            contentDiv.style.display = 'none';
-            button.textContent = '詳細を見る';
-          } else {
-            contentDiv.style.display = 'block';
-            button.textContent = '詳細を隠す';
-          }
-        }
-      });
-    });
-
-  });
-</script>
-
-<script type="module">
+<script type="module" is:inline>
   // Ensure DOM is ready, then load and register web components
   async function initializeComponents() {
     try {
@@ -742,46 +701,6 @@ const summariesByStatus = {
     text-decoration: none;
   }
 
-  .summary-full-content {
-    border-top: 1px solid #e5e7eb;
-    background: #fafafa;
-  }
-
-  .content-divider {
-    height: 1px;
-    background: #e5e7eb;
-    margin: 0;
-  }
-
-  .full-content-text {
-    padding: 1.5rem;
-    line-height: 1.7;
-    color: #374151;
-  }
-
-  .full-content-text h1,
-  .full-content-text h2,
-  .full-content-text h3 {
-    color: #1f2937;
-    font-weight: 600;
-    margin: 1rem 0 0.5rem 0;
-  }
-
-  .full-content-text h1 {
-    font-size: 1.5rem;
-  }
-
-  .full-content-text h2 {
-    font-size: 1.25rem;
-  }
-
-  .full-content-text h3 {
-    font-size: 1.125rem;
-  }
-
-  .full-content-text p {
-    margin: 0.75rem 0;
-  }
 
 
   .empty-state {

--- a/website/src/utils/journal-date.ts
+++ b/website/src/utils/journal-date.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Extract the next journal date from workdesk/sources.md title
+ * Expected format: "# Sources for Journal YYYY-MM-DD"
+ */
+export function getNextJournalDate(): string {
+  const workdeskPath = join(process.cwd(), '../workdesk');
+  const sourcesPath = join(workdeskPath, 'sources.md');
+
+  if (!existsSync(sourcesPath)) {
+    console.warn(`Workdesk sources file not found: ${sourcesPath}`);
+    return getDefaultNextJournalDate();
+  }
+
+  try {
+    const content = readFileSync(sourcesPath, 'utf-8');
+    
+    // Match title pattern: "# Sources for Journal 2025-08-30"
+    const titleMatch = content.match(/^#\s+Sources for Journal\s+(\d{4}-\d{2}-\d{2})/m);
+    
+    if (titleMatch && titleMatch[1]) {
+      const date = titleMatch[1];
+      
+      // Validate date format
+      if (isValidDateFormat(date)) {
+        return date;
+      } else {
+        console.warn(`Invalid date format in sources.md: ${date}`);
+      }
+    } else {
+      console.warn('Could not find journal date in sources.md title');
+    }
+  } catch (error) {
+    console.warn('Failed to read workdesk/sources.md:', error);
+  }
+
+  // Fallback to calculated next date
+  return getDefaultNextJournalDate();
+}
+
+/**
+ * Check if the given date is the next journal date
+ */
+export function isNextJournalDate(date: string): boolean {
+  return date === getNextJournalDate();
+}
+
+/**
+ * Get journal status based on date
+ */
+export function getJournalStatus(date: string): 'published' | 'draft' {
+  return isNextJournalDate(date) ? 'draft' : 'published';
+}
+
+/**
+ * Get status label for display
+ */
+export function getJournalStatusLabel(date: string): string {
+  if (isNextJournalDate(date)) {
+    return `次号掲載予定 (${date}号)`;
+  } else {
+    return `掲載済み (${date}号)`;
+  }
+}
+
+/**
+ * Validate YYYY-MM-DD date format
+ */
+function isValidDateFormat(dateString: string): boolean {
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRegex.test(dateString)) {
+    return false;
+  }
+
+  // Check if it's a valid date
+  const date = new Date(dateString);
+  return date.toISOString().startsWith(dateString);
+}
+
+/**
+ * Calculate default next journal date (next Friday)
+ * This is used as fallback when sources.md is not available or parseable
+ */
+function getDefaultNextJournalDate(): string {
+  const today = new Date();
+  const nextFriday = new Date(today);
+  
+  // Calculate next Friday (assuming journals are published on Fridays)
+  const daysUntilFriday = (5 - today.getDay() + 7) % 7;
+  const daysToAdd = daysUntilFriday === 0 ? 7 : daysUntilFriday; // If today is Friday, get next Friday
+  
+  nextFriday.setDate(today.getDate() + daysToAdd);
+  
+  return nextFriday.toISOString().split('T')[0];
+}
+
+/**
+ * Format date for display in Japanese
+ */
+export function formatJapaneseDateDisplay(date: string): string {
+  try {
+    const dateObj = new Date(date);
+    return dateObj.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      weekday: 'long',
+    });
+  } catch (error) {
+    console.warn('Failed to format Japanese date:', error);
+    return date;
+  }
+}

--- a/website/src/utils/workdesk-parser.ts
+++ b/website/src/utils/workdesk-parser.ts
@@ -1,0 +1,260 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface WorkdeskSummary {
+  id: string; // 3-digit ID from filename
+  filename: string; // Original filename
+  title: string; // Extracted from markdown
+  excerpt: string; // Brief summary
+  url: string; // Reconstructed URL
+  domain: string; // Source domain
+  modifiedAt: Date; // File modification time
+  wordCount: number; // Word count
+  scores?: {
+    signal?: number;
+    depth?: number;
+    unique?: number;
+    practical?: number;
+    antiHype?: number;
+    mainJournal?: number;
+    annexPotential?: number;
+    overall?: number;
+  };
+  topics?: string[];
+}
+
+function extractTitleFromMarkdown(content: string): string {
+  // Look for first heading (## title format)
+  const titleMatch = content.match(/^##\s+(.+)$/m);
+  if (titleMatch) {
+    return titleMatch[1].trim();
+  }
+
+  // Fallback to first non-empty line
+  const lines = content.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith('##') && !trimmed.startsWith('https://')) {
+      return trimmed.substring(0, 100);
+    }
+  }
+
+  return 'Untitled';
+}
+
+function extractExcerpt(content: string, maxLength: number = 150): string {
+  // Find the main Japanese summary paragraph (usually after the first URL)
+  const lines = content.split('\n');
+  let foundUrl = false;
+  
+  for (const line of lines) {
+    const trimmed = line.trim();
+    
+    // Skip until after URL and metadata
+    if (trimmed.startsWith('https://')) {
+      foundUrl = true;
+      continue;
+    }
+    
+    if (trimmed.startsWith('**') || trimmed.startsWith('[[')) {
+      continue;
+    }
+    
+    // Look for substantial Japanese content
+    if (foundUrl && trimmed.length > 20 && /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(trimmed)) {
+      return trimmed.length > maxLength ? `${trimmed.substring(0, maxLength)}...` : trimmed;
+    }
+  }
+
+  // Fallback: get first paragraph with Japanese characters
+  const paragraphs = content.split('\n\n');
+  for (const paragraph of paragraphs) {
+    const trimmed = paragraph.trim();
+    if (trimmed.length > 20 && /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(trimmed)) {
+      return trimmed.length > maxLength ? `${trimmed.substring(0, maxLength)}...` : trimmed;
+    }
+  }
+
+  return content.substring(0, maxLength) + '...';
+}
+
+function extractUrlFromContent(content: string): string {
+  // Look for URL in the content (usually the first https:// line)
+  const urlMatch = content.match(/^https?:\/\/[^\s]+$/m);
+  if (urlMatch) {
+    return urlMatch[0];
+  }
+  
+  return '';
+}
+
+function extractScores(content: string): WorkdeskSummary['scores'] {
+  const scores: WorkdeskSummary['scores'] = {};
+  
+  // Extract scores line: **Scores**: Signal:4/5 | Depth:3/5 | Unique:4/5 | Practical:3/5 | Anti-Hype:5/5
+  const scoresMatch = content.match(/\*\*Scores\*\*:\s*(.+)$/m);
+  if (scoresMatch) {
+    const scoresLine = scoresMatch[1];
+    
+    const signalMatch = scoresLine.match(/Signal:(\d+)\/5/);
+    if (signalMatch) scores.signal = parseInt(signalMatch[1], 10);
+    
+    const depthMatch = scoresLine.match(/Depth:(\d+)\/5/);
+    if (depthMatch) scores.depth = parseInt(depthMatch[1], 10);
+    
+    const uniqueMatch = scoresLine.match(/Unique:(\d+)\/5/);
+    if (uniqueMatch) scores.unique = parseInt(uniqueMatch[1], 10);
+    
+    const practicalMatch = scoresLine.match(/Practical:(\d+)\/5/);
+    if (practicalMatch) scores.practical = parseInt(practicalMatch[1], 10);
+    
+    const antiHypeMatch = scoresLine.match(/Anti-Hype:(\d+)\/5/);
+    if (antiHypeMatch) scores.antiHype = parseInt(antiHypeMatch[1], 10);
+  }
+  
+  // Extract journal scores: **Main Journal**: 77/100 | **Annex Potential**: 79/100 | **Overall**: 76/100
+  const journalMatch = content.match(/\*\*Main Journal\*\*:\s*(\d+)\/100.*?\*\*Annex Potential\*\*:\s*(\d+)\/100.*?\*\*Overall\*\*:\s*(\d+)\/100/);
+  if (journalMatch) {
+    scores.mainJournal = parseInt(journalMatch[1], 10);
+    scores.annexPotential = parseInt(journalMatch[2], 10);
+    scores.overall = parseInt(journalMatch[3], 10);
+  }
+  
+  return scores;
+}
+
+function extractTopics(content: string): string[] {
+  // Extract topics: **Topics**: [[AI Hype, ソフトウェア品質, 開発者の生産性, リソース配分, オープンソース]]
+  const topicsMatch = content.match(/\*\*Topics\*\*:\s*\[\[(.+?)\]\]/);
+  if (topicsMatch) {
+    return topicsMatch[1].split(',').map(topic => topic.trim());
+  }
+  
+  return [];
+}
+
+function parseSummaryFilename(filename: string): {
+  id: string;
+  domain: string;
+  path: string;
+  url: string;
+} | null {
+  try {
+    // Remove .md extension
+    const nameWithoutExt = filename.replace(/\.md$/, '');
+
+    // Parse format: 001_domain_com_path.md
+    const match = nameWithoutExt.match(/^(\d{3})_(.+)$/);
+    if (match) {
+      const [, id, urlPart] = match;
+
+      // Parse domain and path
+      const parts = urlPart.split('_');
+      if (parts.length < 1) {
+        return null;
+      }
+
+      // Reconstruct domain (replace first underscore back to dot)
+      const domain = parts[0] + '.' + parts[1];
+      const path = parts.slice(2).join('/');
+
+      // Reconstruct URL
+      const url = `https://${domain}${path ? `/${path}` : ''}`;
+
+      return { id, domain, path, url };
+    }
+
+    return null;
+  } catch (error) {
+    console.warn(`Failed to parse summary filename ${filename}:`, error);
+    return null;
+  }
+}
+
+function countWords(text: string): number {
+  // Count both Japanese characters and English words
+  const japaneseChars = (text.match(/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g) || []).length;
+  const englishWords = (text.match(/\b[A-Za-z]+\b/g) || []).length;
+
+  // Approximate: 1 Japanese character ≈ 0.5 words
+  return Math.round(japaneseChars * 0.5 + englishWords);
+}
+
+function parseWorkdeskSummaryFile(filePath: string): WorkdeskSummary | null {
+  try {
+    if (!existsSync(filePath)) {
+      return null;
+    }
+
+    const filename = filePath.split('/').pop() || '';
+    const parsedFilename = parseSummaryFilename(filename);
+
+    if (!parsedFilename) {
+      return null;
+    }
+
+    const content = readFileSync(filePath, 'utf-8');
+    const stats = statSync(filePath);
+    
+    const title = extractTitleFromMarkdown(content);
+    const excerpt = extractExcerpt(content);
+    const url = extractUrlFromContent(content) || parsedFilename.url;
+    const wordCount = countWords(content);
+    const scores = extractScores(content);
+    const topics = extractTopics(content);
+
+    return {
+      id: parsedFilename.id,
+      filename,
+      title,
+      excerpt,
+      url,
+      domain: parsedFilename.domain,
+      modifiedAt: stats.mtime,
+      wordCount,
+      scores,
+      topics,
+    };
+  } catch (error) {
+    console.warn(`Failed to parse workdesk summary file ${filePath}:`, error);
+    return null;
+  }
+}
+
+export function getWorkdeskPath(): string {
+  // Point to the workdesk directory relative to the website directory
+  return join(process.cwd(), '../workdesk');
+}
+
+export function getAllWorkdeskSummaries(): WorkdeskSummary[] {
+  const workdeskPath = getWorkdeskPath();
+  const summariesPath = join(workdeskPath, 'summaries');
+
+  try {
+    if (!existsSync(summariesPath)) {
+      console.warn(`Workdesk summaries directory not found: ${summariesPath}`);
+      return [];
+    }
+
+    const files = readdirSync(summariesPath);
+    const summaryFiles = files.filter(file => 
+      file.endsWith('.md') && 
+      /^\d{3}_/.test(file) // Only files starting with 3-digit ID
+    );
+
+    const summaries = summaryFiles
+      .map(file => {
+        const filePath = join(summariesPath, file);
+        return parseWorkdeskSummaryFile(filePath);
+      })
+      .filter((summary): summary is WorkdeskSummary => summary !== null);
+
+    // Sort by modification time (latest first)
+    summaries.sort((a, b) => b.modifiedAt.getTime() - a.modifiedAt.getTime());
+
+    return summaries;
+  } catch (error) {
+    console.warn('Failed to read workdesk summaries directory:', error);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- Added workdesk summaries sidebar to homepage with two-column layout
- Implemented summary detail pages that work for both workdesk (draft) and published summaries
- Added next journal date management system for seamless editorial workflow
- Updated layout container widths to accommodate new sidebar (1200px → 1440px)

## Features Added
- **WorkdeskSidebar component**: Displays current workdesk summaries with metadata, scores, and topics
- **Summary detail pages**: Single route handles both workdesk and published content with proper status indicators
- **Editorial workflow integration**: URLs remain stable throughout development to publication process
- **Responsive design**: Graceful degradation on mobile/tablet with collapsible sidebar

## Test plan
- [ ] Verify workdesk summaries display correctly in homepage sidebar
- [ ] Test summary detail page navigation for both workdesk and published summaries
- [ ] Confirm responsive layout works on mobile devices
- [ ] Check that all links and navigation elements function properly
- [ ] Validate metadata display for scores and topics in sidebar

🤖 Generated with [Claude Code](https://claude.ai/code)