### PR TITLE
Add missing journal-metadata.json for 2025-09-20

### DIFF
--- a/journals/2025-09-20/gemini/journal-metadata.json
+++ b/journals/2025-09-20/gemini/journal-metadata.json
@@ -1,0 +1,9 @@
+{
+  "date": "2025-09-20",
+  "totalSummaries": 172,
+  "statistics": {
+    "mainSummaries": 25,
+    "annexSummaries": 18,
+    "omittedSummaries": 129
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the missing `journal-metadata.json` file for the 2025-09-20 journal. This file is **required** for the website to build correctly.

## Details

- **Total summaries**: 172 individual article summaries
- **Main journal articles**: 25 articles selected for the main journal
- **Annex journal articles**: 18 articles selected for the annex journal  
- **Omitted summaries**: 129 articles not included in either journal

## File Location

`journals/2025-09-20/gemini/journal-metadata.json`

## Critical Fix

Without this metadata file, the website build will fail. This fixes a missing dependency for the 2025-09-20 journal that was already merged and published.

🤖 Generated with [Claude Code](https://claude.ai/code)