### PR TITLE
Add github-sync skill for workdesk workflow tracking

### DIFF
--- a/.claude/skills/github-sync/SKILL.md
+++ b/.claude/skills/github-sync/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: github-sync
+description: Sync entire workdesk/ directory to GitHub issues and pull requests for comprehensive workflow progress tracking across all steps.
+allowed-tools: Read, Bash, Grep, Glob, Edit, mcp__github-server__list_issues, mcp__github-server__create_issue, mcp__github-server__update_issue, mcp__github-server__search_issues, mcp__github-server__list_pull_requests, mcp__github-server__get_pull_request, mcp__github-server__update_pull_request, mcp__github-server__create_pull_request
+---
+
+# GitHub Sync Skill
+
+Syncs the entire `workdesk/` directory to GitHub issues and pull requests for comprehensive workflow progress tracking.
+
+## When to Use This Skill
+
+Use this skill ONLY when:
+- User explicitly says "sync to GitHub" or "sync workdesk to GitHub"
+- User says "update workflow issue" or "sync workflow progress"
+- User says "create workflow PR" or "update workflow PR"
+- User wants to sync workflow progress with team
+
+**Do NOT use this skill when**:
+- User asks to create PR for code changes (not workflow tracking)
+- User asks to update issues unrelated to workflow tracking
+- General GitHub operations not related to workdesk sync
+
+## Core Workflow
+
+### 1. Analyze Workdesk State
+
+Scan workdesk directory to gather metrics:
+
+```bash
+# Count sources
+grep -c "^- \[.\]" workdesk/sources.md
+grep -c "^- \[x\]" workdesk/sources.md
+grep -c "^- \[ \]" workdesk/sources.md
+
+# Count summaries
+find workdesk/summaries -name "*.md" -type f | wc -l
+
+# Check for key files
+ls workdesk/unified_summaries.md
+ls workdesk/editorial_plan_*.md
+ls workdesk/curated_journal_sources.md
+ls workdesk/non_main_sources.md
+```
+
+Extract:
+- Journal date from `workdesk/sources.md` title
+- Total/checked/unchecked link counts
+- Summary file counts
+- Presence of workflow milestone files
+- Current workflow stage (reference STEP_* docs if needed)
+
+### 2. Commit Pending Changes
+
+**CRITICAL**: Commit all workdesk changes before updating GitHub.
+
+```bash
+# Check status
+git status --porcelain workdesk/
+
+# Commit by category if changes exist
+git add workdesk/summaries/
+git commit -m "Add summaries for journal [DATE]
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+
+# Push to branch
+git push
+```
+
+### 3. Update GitHub Issue
+
+1. **Get repository info**: Extract owner/repo from `git remote get-url origin`
+2. **Search for issue**: Use `mcp__github-server__search_issues` for title pattern `"Journal Workflow - Week of YYYY-MM-DD"`
+3. **Create or update**:
+   - If not found: Use `issue-template.md` to create new issue
+   - If found: Update issue with current metrics
+4. **Apply labels**: `workflow-tracking`, `journal-YYYY-MM-DD`, `step-XX`
+
+### 4. Create or Update Pull Request
+
+1. **Get current branch**: `git branch --show-current`
+2. **Search for PR**: Use `mcp__github-server__list_pull_requests` with head filter
+3. **If PR not found**: Create new draft PR using `mcp__github-server__create_pull_request`
+4. **If PR found**:
+   - Check PR status with `mcp__github-server__get_pull_request`
+   - Update if open/draft using `mcp__github-server__update_pull_request`
+   - Skip if closed (report to user)
+5. **Use `pr-template.md`** for PR description
+
+### 5. Report Results
+
+Provide summary with:
+- Issue and PR links
+- Current workflow stage
+- Key metrics (sources, summaries, completion %)
+- What was committed
+
+## Templates
+
+Use separate template files for content:
+- **Issue body**: See `issue-template.md`
+- **PR description**: See `pr-template.md`
+
+Read these files and populate with current metrics.
+
+## Key Responsibilities
+
+- ✅ Analyze entire workdesk/ directory
+- ✅ Determine current workflow stage
+- ✅ Commit all pending changes
+- ✅ Create/update GitHub issues
+- ✅ Create draft PR if not exists
+- ✅ Update open/draft PRs
+- ✅ Calculate completion metrics
+
+## What This Does NOT Do
+
+- ❌ Close pull requests or issues
+- ❌ Update closed PRs
+- ❌ Modify workdesk files
+- ❌ Execute workflow steps
+
+## Error Handling
+
+- **Git conflicts**: Report, ask user to resolve
+- **Closed PR**: Report, skip update
+- **GitHub API errors**: Report error, suggest retry
+
+## Project Standards
+
+- Use relative paths from repository root
+- Issue title: `Journal Workflow - Week of YYYY-MM-DD`
+- PR title: `Journal YYYY-MM-DD - [Current Stage]`
+- Always commit before GitHub operations
+- Create draft PRs by default
+- Never expose absolute paths from user's computer
+
+You are thorough and systematic, analyzing workdesk to provide complete workflow visibility. You commit changes safely, update GitHub accurately, and create PRs when needed to enable collaborative editing.

--- a/.claude/skills/github-sync/issue-template.md
+++ b/.claude/skills/github-sync/issue-template.md
@@ -1,0 +1,125 @@
+# GitHub Issue Template
+
+Use this template when creating or updating workflow tracking issues.
+
+## Title Format
+
+```
+Journal Workflow - Week of YYYY-MM-DD
+```
+
+## Body Template
+
+```markdown
+## Workflow Progress
+
+**Current Stage**: STEP_XX - [Stage Name]
+
+**Overall Progress**: X/14 steps completed (Y%)
+
+---
+
+## STEP_01-02: Source Collection & Summaries
+
+### Sources (workdesk/sources.md)
+- **Total Links**: X
+- **Processed (Checked)**: Y (Z%)
+- **Pending (Unchecked)**: N
+
+### Summaries (workdesk/summaries/)
+- **Files Generated**: X/Y
+- **Status**: [✅ Complete / ⏳ In Progress / ❌ Not Started]
+
+---
+
+## STEP_03: Unified Summaries
+
+### Main Summaries (workdesk/unified_summaries.md)
+- **Status**: [✅ Generated / ⏳ Pending / ❌ Not Started]
+- **Word Count**: X words (if generated)
+- **Summary Count**: Y summaries (if generated)
+
+---
+
+## STEP_03b: Editorial Planning
+
+### Editorial Plan (workdesk/editorial_plan_*.md)
+- **Status**: [✅ Approved / 📝 Draft / ❌ Not Started]
+- **Themes Identified**: X themes (if exists)
+- **Approval Status**: [APPROVED / PENDING REVIEW / N/A]
+
+---
+
+## STEP_04-05: Journal Curation
+
+### Main Journal (workdesk/curated_journal_sources.md)
+- **Status**: [✅ Complete / ⏳ In Progress / ❌ Not Started]
+- **Articles Selected**: X articles (if exists)
+
+### Non-Main Sources (workdesk/non_main_sources.md)
+- **Status**: [✅ Complete / ⏳ In Progress / ❌ Not Started]
+- **Annex Articles**: X articles (if exists)
+
+### Annex Summaries (workdesk/unified_summaries_annex.md)
+- **Status**: [✅ Generated / ⏳ Pending / ❌ Not Started]
+
+---
+
+## STEP_06-14: Journal Assembly & Publication
+
+[Note presence of any advanced stage files if detected]
+
+---
+
+## Workdesk Files
+
+<details>
+<summary>View all workdesk files (X files)</summary>
+
+```
+[Output of: tree workdesk/ or ls -R workdesk/]
+```
+
+</details>
+
+---
+
+## Next Steps
+
+- [ ] [Next action based on current stage]
+- [ ] [Blocking issues or dependencies]
+
+---
+
+## Source Links
+
+<details>
+<summary>View all source URLs (X total, Y processed)</summary>
+
+[Complete contents of workdesk/sources.md]
+
+</details>
+
+---
+
+**Last Updated**: [ISO 8601 timestamp]
+**Branch**: [current-branch-name]
+**Commit**: [short SHA]
+```
+
+## Labels to Apply
+
+- `workflow-tracking`
+- `journal-YYYY-MM-DD` (extract date from sources.md)
+- `step-XX` (current step number)
+
+## Dynamic Content Instructions
+
+Replace placeholders:
+- `YYYY-MM-DD`: Extract from `# Sources for Journal YYYY-MM-DD` in sources.md
+- `X/14 steps`: Count completed workflow milestones
+- Link counts: Parse `- [x]` vs `- [ ]` in sources.md
+- File statuses: Check file existence with `ls` or Read tool
+- Word/summary counts: Parse files if they exist
+- Timestamps: Use ISO 8601 format
+- Branch/commit: From `git branch --show-current` and `git rev-parse --short HEAD`

--- a/.claude/skills/github-sync/pr-template.md
+++ b/.claude/skills/github-sync/pr-template.md
@@ -1,0 +1,122 @@
+# Pull Request Description Template
+
+Use this template when creating or updating PR descriptions for workflow tracking.
+
+## PR Title Format
+
+```
+Journal YYYY-MM-DD - [Current Stage]
+```
+
+Examples:
+- `Journal 2026-01-20 - WIP: Gathering Sources`
+- `Journal 2026-01-20 - Draft: Curation in Progress`
+- `Journal 2026-01-20 - Ready for Review`
+
+## PR Description Template
+
+```markdown
+## Journal YYYY-MM-DD - Workflow Progress
+
+**Current Stage**: STEP_XX - [Stage Name]
+
+**Overall Progress**: X/14 steps (Y%)
+
+---
+
+### Recent Updates
+
+- [List recent changes since last PR update]
+- [What files were added/modified]
+- [What milestones were reached]
+
+---
+
+### Workflow Checklist
+
+**Source Collection & Summaries**
+- [x] STEP_01: Gather sources (X links)
+- [x] STEP_02: Generate summaries (Y summaries)
+- [x] STEP_03: Create unified summaries
+
+**Editorial Planning & Curation**
+- [ ] STEP_03b: Plan editorial themes
+- [ ] STEP_04: Curate main journal
+- [ ] STEP_05: Identify non-main sources
+
+**Journal Assembly**
+- [ ] STEP_06-11: [Assembly steps]
+- [ ] STEP_12: Final review
+- [ ] STEP_13-14: Publication
+
+---
+
+### Current Metrics
+
+| Metric | Count | Status |
+|--------|-------|--------|
+| Total Sources | X | - |
+| Processed Sources | Y | Z% |
+| Summaries Generated | N | - |
+| Main Articles Curated | M | [Status] |
+| Annex Articles | A | [Status] |
+
+---
+
+### Workdesk Status
+
+- `workdesk/sources.md`: X links (Y checked)
+- `workdesk/summaries/`: N files
+- `workdesk/unified_summaries.md`: [✅ / ⏳ / ❌]
+- `workdesk/editorial_plan_*.md`: [✅ / ⏳ / ❌]
+- `workdesk/curated_journal_sources.md`: [✅ / ⏳ / ❌]
+
+---
+
+### Next Steps
+
+1. [Next immediate action]
+2. [Upcoming milestone]
+3. [Any blockers or dependencies]
+
+---
+
+**Related Issue**: #XXX (Weekly workflow tracking issue)
+
+**Branch**: `[branch-name]`
+**Last Updated**: [ISO 8601 timestamp]
+```
+
+## PR Creation Settings
+
+When creating a new PR:
+
+```json
+{
+  "draft": true,
+  "base": "main",
+  "head": "[feature-branch]",
+  "title": "Journal YYYY-MM-DD - WIP: [Current Stage]",
+  "body": "[Use template above]"
+}
+```
+
+## Dynamic Content Instructions
+
+Replace placeholders:
+- `YYYY-MM-DD`: Extract from sources.md title
+- `STEP_XX`: Current workflow step
+- `X/14 steps`: Count completed milestones
+- Checklist: Mark completed steps with `[x]`, pending with `[ ]`
+- Metrics table: Fill with current counts from workdesk analysis
+- Recent updates: Compare with previous commit messages or list what changed
+- Related issue: Link to weekly tracking issue
+- Branch name: From `git branch --show-current`
+- Timestamp: ISO 8601 format
+
+## PR Update Strategy
+
+- **Draft status**: Keep as draft until STEP_12 (final review)
+- **Title updates**: Update stage name as workflow progresses
+- **Description**: Update entire description with current state
+- **Never update**: Closed PRs (report to user instead)


### PR DESCRIPTION
## Summary

Adds a new `github-sync` skill that syncs the entire workdesk/ directory to GitHub issues and pull requests for comprehensive workflow progress tracking.

## Features

- **Comprehensive workdesk analysis**: Scans all workdesk files to determine current workflow stage
- **Automatic stage detection**: Identifies which STEP the workflow is at (STEP_01-14)
- **Issue management**: Creates or updates weekly workflow tracking issues
- **PR management**: Creates draft PR if not exists, updates existing open/draft PRs
- **Template-based content**: Uses separate template files for issues and PR descriptions
- **Smart triggering**: Only activates for explicit workflow sync requests, not general GitHub operations

## Skill Structure

```
.claude/skills/github-sync/
├── SKILL.md           # Main skill logic
├── issue-template.md  # GitHub issue template
└── pr-template.md     # Pull request template
```

## Usage

The skill activates only when user says:
- "sync to GitHub" / "sync workdesk to GitHub"
- "update workflow issue" / "sync workflow progress"
- "create workflow PR"

## Test Plan

- [ ] Test issue creation with current workdesk state
- [ ] Test PR creation with draft status
- [ ] Test update of existing issue
- [ ] Test update of existing PR
- [ ] Verify proper commit handling before GitHub operations
- [ ] Verify skill doesn't trigger for general GitHub operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)