### PR TITLE
Fix: Refine excerpt extraction to preserve Japanese summary lines

### DIFF
--- a/website/src/pages/journals/[date]/[id].astro
+++ b/website/src/pages/journals/[date]/[id].astro
@@ -63,6 +63,7 @@ type UnifiedSummary = SummaryEntry | (WorkdeskSummary & {
   title: string;
   content: string;
   excerpt: string;
+  fullExcerpt?: string;
   sourceUrl: string;
   domain: string;
   wordCount: number;
@@ -95,6 +96,7 @@ if (isNextJournalDate(date)) {
       title: workdeskSummary.title,
       content: sanitizeContent(workdeskSummary.fullContent || ''),
       excerpt: workdeskSummary.excerpt,
+      fullExcerpt: workdeskSummary.fullExcerpt,
       sourceUrl: workdeskSummary.url,
       domain: workdeskSummary.domain,
       wordCount: workdeskSummary.wordCount,

--- a/website/src/utils/content-parser.ts
+++ b/website/src/utils/content-parser.ts
@@ -159,7 +159,8 @@ function shouldSkipLine(line: string): boolean {
   if (!trimmed) return true;
   if (trimmed.startsWith('#')) return true;
   if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return true;
-  if (trimmed.startsWith('**')) return true;
+  // Skip metadata lines like **Content Type**: but not summary lines like **分析する**：
+  if (/^\*\*[A-Za-z\s]+\*\*:/.test(trimmed)) return true;
   if (trimmed.startsWith('[[')) return true;
   return false;
 }

--- a/website/src/utils/workdesk-parser.ts
+++ b/website/src/utils/workdesk-parser.ts
@@ -87,7 +87,8 @@ function shouldSkipLine(line: string): boolean {
   if (!trimmed) return true;
   if (trimmed.startsWith('#')) return true;
   if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return true;
-  if (trimmed.startsWith('**')) return true;
+  // Skip metadata lines like **Content Type**: but not summary lines like **分析する**：
+  if (/^\*\*[A-Za-z\s]+\*\*:/.test(trimmed)) return true;
   if (trimmed.startsWith('[[')) return true;
   return false;
 }


### PR DESCRIPTION
## Summary
This PR refines the excerpt extraction fix from PR #77 to correctly handle Japanese summary lines.

## Problem in PR #77
The previous fix used an overly broad filter that skipped ALL lines starting with `**`, which inadvertently skipped the Japanese short summary line `**分析する**：...` that should be displayed in the excerpt.

**Result**: Excerpts showed the long detailed paragraph instead of the intended short summary.

## Root Cause
```typescript
// ❌ Previous fix in PR #77 - too broad
if (trimmed.startsWith('**')) return true;
```

This skipped:
- `**Content Type**:` ✓ (metadata - should skip)
- `**Language**:` ✓ (metadata - should skip)
- `**分析する**：` ❌ (short summary - should NOT skip!)

## Solution
Replace with a specific regex pattern that only matches English metadata:

```typescript
// ✅ New fix - specific
if (/^\*\*[A-Za-z\s]+\*\*:/.test(trimmed)) return true;
```

This skips only lines with **English** keys:
- `**Content Type**:` ✓ Skip
- `**Language**:` ✓ Skip
- `**Scores**:` ✓ Skip

But preserves **Japanese** summary lines:
- `**分析する**：` ✗ Keep for excerpt

## Additional Fix
Also adds the `fullExcerpt` field to the workdesk summary template object (missing in PR #77), allowing the template to access and display the extracted short summary.

## Changes
1. **Both parsers** (`content-parser.ts`, `workdesk-parser.ts`):
   - Replace `startsWith('**')` with regex `/^\*\*[A-Za-z\s]+\*\*:/`
   
2. **Page template** (`[id].astro`):
   - Add `fullExcerpt?: string` to UnifiedSummary type
   - Add `fullExcerpt: workdeskSummary.fullExcerpt` to summary object

## Verification
Tested with `/journals/2026-02-07/159/` - excerpt now correctly shows:
> **分析する**：Anthropicの新ツールが引き起こした既存ソフト・サービス企業の株価急落に対し、既存企業が保有する**独自ビジネスデータ**の価値という観点から市場の過剰反応を論じる。

## Files Modified
- `website/src/utils/content-parser.ts`
- `website/src/utils/workdesk-parser.ts`
- `website/src/pages/journals/[date]/[id].astro`

Fixes: #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)