### PR TITLE
Fix: encode HTML angle brackets in AI-generated summary text fields

### DIFF
--- a/scripts/call-gemini.py
+++ b/scripts/call-gemini.py
@@ -181,6 +181,16 @@ def validate_json_summary(data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
         return False, f"Validation error: {str(e)}"
 
 
+def sanitize_html_in_text(text: str) -> str:
+    """Encode HTML angle brackets to entity references.
+
+    Prevents raw HTML tags in AI-generated text from being
+    stripped by DOMPurify during rendering. Only encodes
+    < and > to avoid double-encoding existing entities like &amp;.
+    """
+    return text.replace('<', '&lt;').replace('>', '&gt;')
+
+
 def get_gemini_schema():
     """Get Gemini-compatible schema for structured output.
 
@@ -616,6 +626,14 @@ def main():
                 sys.exit(1)
 
             logging.info("JSON validation passed")
+
+            # Sanitize HTML in text fields to prevent raw tags from being stripped by DOMPurify
+            if 'content' in response_data:
+                content = response_data['content']
+                for field in ('summaryBody', 'oneSentenceSummary', 'title'):
+                    if field in content and isinstance(content[field], str):
+                        content[field] = sanitize_html_in_text(content[field])
+                logging.info("HTML sanitization applied to text fields")
 
             # URL enforcement: Gemini sometimes writes a different URL in the JSON output field
             # even though it fetched content from the correct URL. Force the URL to match args.url.


### PR DESCRIPTION
## Summary

- Add `sanitize_html_in_text()` helper in `scripts/call-gemini.py` that encodes `<` and `>` to `&lt;`/`&gt;`
- Apply sanitization to `summaryBody`, `oneSentenceSummary`, and `title` fields after JSON validation passes, before serialization
- Only encode angle brackets (not `&`) to avoid double-encoding existing HTML entities like `&amp;`

## Problem

Gemini sometimes generates text fields containing raw HTML tags (e.g. `<br>`, `<em>`, `<div>`). The rendering pipeline was:

1. `summaryBody` (markdown with raw HTML) → micromark → HTML output
2. DOMPurify **strips** the raw tags entirely → text silently disappears from the browser

## Fix

Encode `<` and `>` at generation time so tags display as literal characters (`&lt;br&gt;`) rather than being stripped.

## Rendering Pipeline After Fix

```
Gemini generates summaryBody with raw HTML tags (e.g., <br>)
    ↓
validate_json_summary() checks structure/lengths (passes)
    ↓
sanitize_html_in_text() encodes: <br> → &lt;br&gt;
    ↓
JSON saved with encoded body
    ↓
DOMPurify sees no raw HTML tags → no stripping
    ↓
micromark renders &lt;br&gt; as literal text "<br>" in browser ✓
```

## Files Changed

- `scripts/call-gemini.py` — added `sanitize_html_in_text()` and applied it in `main()`