### PR TITLE
feat: re-generate summary trigger and fallback chain (closes #99)

### DIFF
--- a/.claude/skills/summarize-source/SKILL.md
+++ b/.claude/skills/summarize-source/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: summarize-source
-description: Generate summaries for unchecked sources in workdesk/sources.md. Supports single URL or batch processing. Use after adding URLs with add-url skill.
+description: Generate summaries for unchecked sources in workdesk/sources.md. Supports single URL, batch processing, and re-generation of existing summaries via a structured fallback chain. Use after adding URLs with add-url skill.
 allowed-tools: Read, Edit, Bash, Grep, Glob
 ---
 
 # Summarize Source URLs
 
-This skill generates Japanese summaries for unchecked URLs in `workdesk/sources.md`. It can process a single URL by ID or batch-process all unchecked URLs at once.
+This skill generates Japanese summaries for unchecked URLs in `workdesk/sources.md`. It can process a single URL by ID, batch-process all unchecked URLs at once, or **re-generate an existing summary** via a structured fallback chain when an earlier attempt produced poor output.
 
 ## When to Use This Skill
 
@@ -15,6 +15,12 @@ Use this skill when:
 - After adding URLs with `add-url` skill
 - User wants to process unchecked URLs in sources.md
 - Need to generate summary for a specific ID
+- **Re-generation triggers** (fallback chain in [Re-generation Workflow](#re-generation-workflow)):
+  - "re-generate summary [ID]"
+  - "re-summarize [ID]"
+  - "regenerate [ID]"
+  - "redo summary for [ID]"
+  - "fix summary [ID]" (when an existing summary is wrong/low quality)
 
 ## Workflow Options
 
@@ -86,6 +92,219 @@ For processing a subset of unchecked URLs.
 ```
 
 **Note**: This is more complex and usually not needed. Prefer Option 1 or Option 2.
+
+## Re-generation Workflow
+
+Use this workflow when an existing summary is **already on disk** but is wrong, hallucinated, or low quality, and the user asks to regenerate it. Trigger phrases:
+
+- "re-generate summary [ID]"
+- "re-summarize [ID]"
+- "regenerate [ID]"
+- "redo summary for [ID]" / "fix summary [ID]"
+
+Re-generation **must follow the fallback chain below in order**. Do not skip steps. Each step has a clear failure signal that escalates to the next step. After success, **report which step succeeded** so the editor can audit later (e.g. `Regeneration succeeded at Step 4 (curl-fed retry)`).
+
+### Step 1 — Diagnose existing summary
+
+Read the existing JSON to understand the failure mode before doing anything else.
+
+```bash
+# Workdesk (in-progress) summaries:
+ls workdesk/summaries/${ID}_*.json 2>/dev/null
+
+# Or, if already archived to a published journal:
+ls journals/*/summaries/${ID}_*.json 2>/dev/null
+```
+
+Read the file with the Read tool, then classify the likely root cause:
+
+- **Title looks invented from the domain name** (e.g. `title: "Qiitaの記事"` for a Qiita URL) → fetch likely failed, page returned an error or login wall
+- **Summary describes the company/product, not the article** (e.g. summary of WSJ.com instead of the WSJ article) → paywall or bot block returned a generic landing page
+- **`oneSentenceSummary` and `summaryBody` are vague or about a 404 page** → broken URL or redirect to home
+- **Schema-valid but contradicts the URL slug** → wrong page fetched (redirect, A/B test, geo-block)
+- **Empty or truncated `summaryBody`** → upstream timeout
+
+Note the diagnosis in your reasoning before proceeding.
+
+### Step 2 — HTTP probe with curl
+
+Check the live HTTP status and redirect chain:
+
+```bash
+curl -sIL --max-time 10 \
+  -A 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36' \
+  "$URL"
+```
+
+Interpret:
+
+- **200 OK with no auth/paywall hints** → page is healthy, jump to **Step 4** (standard retry)
+- **301/302 chain** → note the final URL; if it differs materially from the input (e.g. redirected to a login page), treat as paywall (**Step 3**)
+- **401 / 403** → likely paywall or bot block → **Step 3**
+- **404 / 410** → page is dead; report to user, do not regenerate
+- **5xx** → transient server issue; wait briefly and retry **Step 2** once before moving on
+- **200 OK but `Content-Type` is non-HTML** (e.g. PDF, video) → document and stop; this skill cannot summarize binary content
+
+If the headers look healthy but you saw paywall language in the existing summary (Step 1), also fetch a small body sample to LLM-judge whether the page is gated:
+
+```bash
+curl -sL --max-time 10 -A '...' "$URL" | head -c 4000
+```
+
+Look for telltale phrases: "Subscribe to continue", "Sign in to read", "members only", a near-empty `<article>` tag, or a paywall component name in HTML class attributes.
+
+### Step 3 — Paywall path: swap to Hacker News thread
+
+If Step 2 indicates a paywall (4xx, login redirect, or LLM-judged gated content), search Hacker News via the Algolia API and re-summarize the thread instead.
+
+```bash
+# URL-encode the input URL, then query Algolia
+ENCODED=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$URL")
+curl -s --max-time 10 "https://hn.algolia.com/api/v1/search?query=${ENCODED}" \
+  | python3 -c "import sys, json; d = json.load(sys.stdin); \
+      hits = [h for h in d.get('hits', []) if h.get('url') and h.get('points', 0) >= 5]; \
+      print(json.dumps([{'id': h['objectID'], 'title': h['title'], 'url': h['url'], 'points': h.get('points', 0)} for h in hits[:5]], indent=2))"
+```
+
+Pick the hit whose `url` matches the input most closely (exact match preferred; otherwise highest-point hit pointing at the same article slug). Convert its `objectID` to an HN thread URL:
+
+```
+https://news.ycombinator.com/item?id=<objectID>
+```
+
+Then run standard generation against the HN thread URL:
+
+```bash
+uv run scripts/call-gemini.py \
+  --url "https://news.ycombinator.com/item?id=<objectID>" \
+  --output "workdesk/summaries/${ID}_news_ycombinator_com.json"
+```
+
+**Mandatory**: after success, document the URL→HN swap in your report so it's auditable. The `content.url` field in the resulting JSON will (correctly) point to the HN thread, not the original paywalled article. Mention both in the user-facing summary report:
+
+```
+Step 3 succeeded. Original URL: <paywalled URL>
+Replaced with HN thread: https://news.ycombinator.com/item?id=<id>
+Output: workdesk/summaries/${ID}_news_ycombinator_com.json
+```
+
+If no HN hit exists, skip to **Step 6** (Playwright).
+
+### Step 4 — Standard retry with call-gemini
+
+If the HTTP probe in Step 2 looks healthy and the page isn't paywalled, the most likely cause is a transient Gemini hiccup. Re-run the standard generation:
+
+```bash
+# Determine domain slug for filename (same convention as initial generation)
+DOMAIN=$(python3 -c "from urllib.parse import urlparse; \
+  print(urlparse('$URL').netloc.replace('.', '_').replace('-', '_'))")
+
+uv run scripts/call-gemini.py \
+  --url "$URL" \
+  --output "workdesk/summaries/${ID}_${DOMAIN}.json"
+```
+
+Then validate:
+
+```bash
+uv run scripts/validate_summaries.py "workdesk/summaries/${ID}_${DOMAIN}.json"
+```
+
+Read the regenerated JSON and sanity-check that `title`, `oneSentenceSummary`, and `summaryBody` actually describe the article (not the diagnosis from Step 1). If it still looks bad, escalate to **Step 5**.
+
+### Step 5 — Curl-fed retry
+
+If `call-gemini.py --url` keeps producing a bad summary even though the page is healthy, the in-script fetch may be hitting a path that bot-walls Gemini's fetcher (e.g. JS-heavy SPA where the in-script extractor returns navigation chrome only). Fetch the raw HTML manually with curl, extract readable text, and feed it to Gemini through the `--file` path with the JSON prompt template.
+
+```bash
+# 1. Fetch raw HTML and extract readable text (mirrors call-gemini's own approach)
+RAW=$(mktemp)
+python3 - "$URL" > "$RAW" <<'PY'
+import sys, subprocess
+from bs4 import BeautifulSoup
+url = sys.argv[1]
+html = subprocess.check_output([
+    'curl', '-sL', '--max-time', '30',
+    '-A', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    '-H', 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    '-H', 'Accept-Language: ja,en;q=0.9',
+    url,
+])
+soup = BeautifulSoup(html, 'html.parser')
+for tag in soup(['script', 'style', 'noscript']):
+    tag.decompose()
+text = ' '.join(chunk.strip() for line in soup.get_text().splitlines() for chunk in line.split('  ') if chunk.strip())
+print(text)
+PY
+```
+
+Then assemble a prompt by inlining the extracted text into `prompts/summarize-json.prompt`. The cleanest route is to call the script with `--file` after substituting `{{url}}` and replacing the auto-fetched template marker with the curled content. **Today there is no `--content` / stdin-content flag on `call-gemini.py`** — see the gap note below. As a workaround, write a temporary prompt file and pass it via `--file`:
+
+```bash
+TMP=$(mktemp --suffix=.prompt)
+python3 - "$URL" "$RAW" > "$TMP" <<'PY'
+import sys, pathlib
+url, raw_path = sys.argv[1], sys.argv[2]
+template = pathlib.Path('prompts/summarize-json.prompt').read_text()
+content = pathlib.Path(raw_path).read_text()
+# Replace {{url}} placeholder, then replace the template's fetch directive
+# with the literal content. The template uses a "# Article Content" marker.
+prompt = template.replace('{{url}}', url)
+# Strip any @fetch directive and append content under the marker
+import re
+prompt = re.sub(r'@fetch\([^)]*\)', '', prompt)
+if '# Article Content' in prompt:
+    head, _ = prompt.split('# Article Content', 1)
+    prompt = head + '# Article Content\n\n' + content
+else:
+    prompt = prompt + '\n\n# Article Content\n\n' + content
+print(prompt)
+PY
+
+uv run scripts/call-gemini.py \
+  --file "$TMP" \
+  --output "workdesk/summaries/${ID}_${DOMAIN}.json" \
+  --model gemini-3-flash-preview
+```
+
+**Known gap (follow-up)**: `call-gemini.py` does not currently expose a `--content` flag or stdin-content mode for "I already have the article text, just summarize it". The workaround above uses `--file` with a hand-built prompt, which bypasses the URL-mode JSON pipeline (the script only auto-applies the structured-output JSON pipeline when `--url` is set). If validation fails on the resulting output, escalate to **Step 6**. A clean fix would be a new `--content <path>` flag that reuses the URL-mode JSON pipeline with externally supplied article text — tracked as a follow-up.
+
+### Step 6 — Playwright last resort
+
+If curl-fed retry still produces a bad summary (likely a JS-rendered SPA, e.g. some Notion/Twitter/X pages, dynamic dashboards), fall back to Playwright MCP to capture the rendered DOM:
+
+1. `mcp__playwright__browser_navigate` to the URL
+2. `mcp__playwright__browser_snapshot` (returns an accessibility tree of the rendered page) — or `mcp__playwright__browser_evaluate` with `() => document.body.innerText` to get rendered text directly
+3. Save the extracted text to a temp file, then run the same `--file` flow as **Step 5** with the Playwright-extracted content
+
+Always close the browser tab after extraction (`mcp__playwright__browser_close`) to free resources.
+
+If Playwright also fails, stop and report:
+
+```
+Regeneration failed at all 6 steps for ID ${ID}.
+Last successful step: <none>
+URL: <url>
+Diagnosis: <step 1 finding>
+Recommendation: manual review or omit from journal
+```
+
+### Re-generation reporting requirements
+
+Every regeneration run must end with a structured report so the editor can audit:
+
+```
+ID: ${ID}
+URL: ${URL}
+Diagnosis (Step 1): <e.g. "title invented from domain; summaryBody describes wsj.com landing page">
+HTTP probe (Step 2): <status code + redirect chain>
+Resolved at: Step <N> (<step name>)
+Output file: workdesk/summaries/${ID}_${DOMAIN}.json
+URL swap (if Step 3): original → HN thread <url>
+Notes: <anything unusual>
+```
+
+Do NOT mark the URL as `[x]` checked in `sources.md` until validation passes (`uv run scripts/validate_summaries.py <output>`).
 
 ## Progress Tracking
 
@@ -281,10 +500,7 @@ uv run scripts/validate_summaries.py workdesk/summaries --quiet
 3. Re-run generation - Gemini will try again with schema enforcement
 
 **Issue**: Want to re-generate a summary
-**Solution**:
-1. Uncheck the URL in sources.md
-2. Delete the old summary file
-3. Run bulk_summarize.py or call-gemini.py
+**Solution**: Use the [Re-generation Workflow](#re-generation-workflow) (triggers: "re-generate summary [ID]", "re-summarize [ID]", "regenerate [ID]"). It walks the 6-step fallback chain — diagnose, HTTP probe, paywall→HN swap, standard retry, curl-fed retry, Playwright last resort — and reports which step succeeded. Avoid the old "uncheck and re-run bulk" approach for known-bad summaries; it doesn't address paywall or fetch-failure root causes.
 
 ## Relationship to Other Skills
 


### PR DESCRIPTION
## Summary

Implements #99 by adding a formalized re-generation workflow to the `summarize-source` skill. Previously, regenerating a bad summary was ad-hoc ("uncheck, delete, re-run") with no diagnosis step and no plan for paywalls or JS-rendered SPAs. This change documents an explicit 6-step fallback chain so the agent picks the right tool for the failure mode and reports which step succeeded for editor audit.

Closes #99.

## Trigger phrases

The skill now activates re-generation on any of:

- `re-generate summary [ID]`
- `re-summarize [ID]`
- `regenerate [ID]`
- `redo summary for [ID]`
- `fix summary [ID]`

## Fallback chain (6 steps)

1. **Diagnose** — Read the existing `workdesk/summaries/NNN_*.json` (or archived `journals/YYYY-MM-DD/summaries/`) and classify the failure mode (title invented from domain, summary describes the company not the article, vague/404 content, wrong page fetched, truncated body)
2. **HTTP probe** — `curl -sIL` for status + redirect chain; branch on 200 / 3xx / 401-403 / 404 / 5xx / non-HTML
3. **Paywall path** — On 4xx or LLM-judged paywall, query `https://hn.algolia.com/api/v1/search?query=<URL>`, pick best match, re-summarize the HN thread URL (`https://news.ycombinator.com/item?id=<objectID>`); document the URL→HN swap in the report
4. **Standard retry** — On healthy 200, re-run `uv run scripts/call-gemini.py --url <URL> --output <path>` (handles transient Gemini hiccups)
5. **Curl-fed retry** — If standard retry still produces a bad summary (likely SPA bot-walling Gemini's fetcher), curl the raw HTML, extract text with BeautifulSoup, build a prompt from `prompts/summarize-json.prompt`, and pass via `--file`
6. **Playwright last resort** — Use `mcp__playwright__browser_navigate` + `browser_snapshot` / `browser_evaluate` to capture rendered DOM, then feed to step 5's `--file` flow

Every run ends with a structured audit report (ID, URL, diagnosis, HTTP status, resolved-at-step, output file, URL swap if any).

## Files changed

- `.claude/skills/summarize-source/SKILL.md` (+222 / -6) — added trigger phrases to "When to Use This Skill", new "Re-generation Workflow" section with all six steps + reporting requirements, and updated the troubleshooting "Want to re-generate a summary" entry to point at the new workflow

## Out of scope (sibling issues / follow-ups)

- **Quality-gate detection (#108)** — being implemented in parallel; no overlap here
- **Validation refactor (#113)** — separate PR
- **Follow-up: `--content` flag for `call-gemini.py`** — Step 5 (curl-fed retry) currently uses a hand-built prompt via `--file`, which bypasses the structured-output JSON pipeline that `--url` triggers. A clean fix would be a new `--content <path>` flag that reuses the URL-mode JSON pipeline with externally supplied article text. Surfaced here per issue scope; not implemented to keep this PR documentation-only and avoid colliding with #108

## Test plan

- [ ] Read the updated SKILL.md as a user and confirm trigger phrases + 6-step procedure are clear
- [ ] Verify HN-swap step works end-to-end on a real paywalled URL (Algolia API spot-checked during authoring; returned valid `objectID` for a WSJ URL)
- [ ] Try `regenerate <some-bad-ID>` against a known-bad summary and confirm the agent walks the chain and produces an audit report
- [ ] Confirm `call-gemini.py` was NOT modified (per #108 parallel work)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>