### PR TITLE
feat: fetch quality gate, review table, and retry workflow for summaries (closes #108)

### DIFF
--- a/.claude/skills/summarize-source/SKILL.md
+++ b/.claude/skills/summarize-source/SKILL.md
@@ -286,6 +286,88 @@ uv run scripts/validate_summaries.py workdesk/summaries --quiet
 2. Delete the old summary file
 3. Run bulk_summarize.py or call-gemini.py
 
+## Batch retry with Playwright
+
+When `scripts/summary_review.py` flags suspicious rows, or when a human reviewer
+identifies summaries that were clearly fabricated from a URL/domain (BS4
+extraction failed on a JS-rendered or bot-blocked page), use the **batch retry
+workflow** to fix multiple summaries at once.
+
+**Trigger phrases the user might use**:
+
+- "re-summarize 092 164 251"
+- "fix summaries 164 and 192 with Playwright"
+- "retry these IDs with the rendered page"
+
+**Workflow per ID**:
+
+For each ID provided, the skill performs these steps in sequence:
+
+1. **Look up the URL** from the appropriate sources file:
+   - Active week: `workdesk/sources.md`
+   - Already-published journal: `journals/YYYY-MM-DD/sources/sources.md`
+   ```bash
+   grep -E "^- \[.\] 164\." workdesk/sources.md
+   ```
+
+2. **Fetch the rendered page with Playwright MCP**, since BS4 already failed.
+   Two options, in order of preference:
+
+   - **Playwright MCP (preferred)**: navigate to the URL via the
+     `mcp__playwright__browser_navigate` tool, then capture the rendered text
+     with `mcp__playwright__browser_evaluate` (e.g.
+     `() => document.body.innerText`) or `browser_snapshot`. Save the
+     extracted text to a temp file (e.g. `/tmp/164_rendered.txt`).
+
+   - **CLI fallback**: re-run `call-gemini.py` with the
+     `--auto-fallback-playwright` flag, which retries the fetch via the
+     in-process Playwright integration when BS4 extraction is below the
+     quality threshold. This is the simpler one-shot path:
+     ```bash
+     uv run scripts/call-gemini.py \
+       --url "URL_FROM_SOURCES" \
+       --auto-fallback-playwright \
+       --output workdesk/summaries/164_domain.json
+     ```
+
+3. **Send the rendered content through `call-gemini.py`** (only needed when
+   you used the MCP option in step 2 to capture text manually):
+   ```bash
+   # Replace the {{fetch:"..."}} block in the prompt with the captured text,
+   # then pipe to call-gemini.py via --file or stdin.
+   ```
+
+4. **Replace the existing JSON file** in `workdesk/summaries/` (or the
+   published `journals/YYYY-MM-DD/summaries/` directory) — the schema
+   validation in `call-gemini.py` ensures the new file is well-formed before
+   it overwrites the old one.
+
+5. **Verify** with `scripts/summary_review.py` that the previously suspicious
+   row is no longer flagged (or run `validate_summaries.py` to confirm
+   schema compliance):
+   ```bash
+   uv run scripts/summary_review.py workdesk/summaries/ --only-suspicious
+   ```
+
+**Quality gate signals** (from Issue #108, Layer 1):
+
+`call-gemini.py` now emits a stderr warning when BS4 extracts fewer than 200
+characters from a page (the typical failure mode for JS-rendered articles).
+When you see `WARN: extracted only N chars from <url>`, treat the resulting
+summary as suspect even if schema validation passes.
+
+**Review table** (from Issue #108, Layer 2):
+
+After a bulk run, append `--review-table` to surface suspicious summaries:
+
+```bash
+uv run scripts/bulk_summarize.py --review-table
+# Or stand-alone over an existing directory:
+uv run scripts/summary_review.py journals/2026-04-18/summaries/ --only-suspicious
+```
+
+Use the flagged IDs as input to the batch retry workflow above.
+
 ## Relationship to Other Skills
 
 - **Before summarize-source**: Use `add-url` skill to add URLs

--- a/scripts/bulk_summarize.py
+++ b/scripts/bulk_summarize.py
@@ -180,6 +180,13 @@ def main():
         action='store_true',
         help='Sync checkbox state with existing summary files'
     )
+    parser.add_argument(
+        '--review-table',
+        action='store_true',
+        help='After the run completes (or instead of running, if no unchecked '
+             'URLs), print a review table of generated summaries with '
+             'suspicious rows flagged for human review (see Issue #108).'
+    )
 
     args = parser.parse_args()
 
@@ -211,6 +218,8 @@ def main():
 
     if not unchecked_urls:
         print("\n✓ No unchecked URLs found. All sources are already processed!")
+        if args.review_table:
+            _print_review_table(summaries_dir)
         sys.exit(0)
 
     print(f"Found {len(unchecked_urls)} unchecked URLs\n")
@@ -274,8 +283,36 @@ def main():
 
     print("\nDone! ✓")
 
+    if args.review_table:
+        _print_review_table(summaries_dir)
+
     if failed > 0:
         sys.exit(1)
+
+
+def _print_review_table(summaries_dir: Path) -> None:
+    """Render the review table from summary_review.py for the given directory.
+
+    Imported lazily so bulk_summarize.py keeps working even if summary_review.py
+    is missing in older trees.
+    """
+    try:
+        # Local import: scripts/ is the parent directory of this file.
+        sys.path.insert(0, str(Path(__file__).parent))
+        import summary_review  # type: ignore
+    except ImportError as e:
+        print(f"\n(could not load summary_review module: {e})", file=sys.stderr)
+        return
+
+    print("\n" + "=" * 60)
+    print("REVIEW TABLE (Issue #108, Layer 2)")
+    print("=" * 60)
+    rows = summary_review.gather_rows(summaries_dir)
+    if not rows:
+        print(f"(no summary files found in {summaries_dir})")
+        return
+    print(summary_review.render_table(rows))
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/call-gemini.py
+++ b/scripts/call-gemini.py
@@ -27,8 +27,118 @@ def _timeout_handler(signum, frame):
 
 from modules.template_processor import process_template, parse_replacements
 
+# Layer 1 (Issue #108) — Fetch quality gate
+# When BeautifulSoup extracts very little text, the page is likely JS-rendered or
+# bot-blocked, and Gemini will hallucinate a summary from the URL/domain.
+# Threshold below which a fetch is considered unreliable.
+FETCH_QUALITY_MIN_CHARS = 200
+
+# Module-level state so the main flow can decide whether to fall back to Playwright.
+# Populated by fetch_url_content() and read in main() — keeps the call signature
+# unchanged for the template processor that invokes it.
+_LAST_FETCH_METRICS: Dict[str, Any] = {}
+
+# When True, fetch_url_content will automatically retry with Playwright if the
+# initial BS4 extraction is below FETCH_QUALITY_MIN_CHARS. Toggled by the
+# --auto-fallback-playwright CLI flag in main().
+_AUTO_FALLBACK_PLAYWRIGHT: bool = False
+
+
+def _emit_fetch_quality_warning(url: str, metrics: Dict[str, Any]) -> None:
+    """Emit a stderr warning when extracted content is below the quality threshold."""
+    extracted = metrics.get('extracted_chars', 0)
+    has_article = metrics.get('has_article_tag', False)
+    has_main = metrics.get('has_main_tag', False)
+    title_len = metrics.get('title_len', 0)
+    print(
+        f"WARN: extracted only {extracted} chars from {url}; summary may be unreliable "
+        f"(article_tag={has_article}, main_tag={has_main}, title_len={title_len})",
+        file=sys.stderr,
+    )
+
+
+def fetch_url_content_playwright(url: str, timeout: int = 60) -> Tuple[str, Dict[str, Any]]:
+    """Fetch URL content using Playwright (handles JS-rendered pages).
+
+    Returns:
+        (text, metrics) tuple. text is the extracted page text; metrics captures
+        extracted_chars, has_article_tag, has_main_tag, title_len, fetcher.
+    """
+    logging.info(f"Playwright fetch: {url}")
+    text = ""
+    metrics: Dict[str, Any] = {
+        'extracted_chars': 0,
+        'has_article_tag': False,
+        'has_main_tag': False,
+        'title_len': 0,
+        'fetcher': 'playwright',
+    }
+
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            try:
+                context = browser.new_context(
+                    user_agent=(
+                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+                        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+                    ),
+                    locale='ja-JP',
+                )
+                page = context.new_page()
+                page.goto(url, timeout=timeout * 1000, wait_until='domcontentloaded')
+                # Give SPAs a brief settle window for late-rendering content.
+                try:
+                    page.wait_for_load_state('networkidle', timeout=10_000)
+                except Exception:
+                    pass
+
+                html = page.content()
+                title_attr = page.title() or ''
+            finally:
+                browser.close()
+
+        soup = BeautifulSoup(html, 'html.parser')
+        for script in soup(["script", "style", "noscript"]):
+            script.decompose()
+
+        metrics['has_article_tag'] = soup.find('article') is not None
+        metrics['has_main_tag'] = soup.find('main') is not None
+        metrics['title_len'] = len(title_attr)
+
+        text = soup.get_text()
+        lines = (line.strip() for line in text.splitlines())
+        chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
+        text = ' '.join(chunk for chunk in chunks if chunk)
+        metrics['extracted_chars'] = len(text)
+        logging.info(f"Playwright extracted {len(text)} characters")
+    except Exception as e:
+        logging.error(f"Playwright fetch failed for {url}: {e}")
+        text = f"[ERROR: Playwright fetch failed: {e}]"
+
+    return text, metrics
+
+
 def fetch_url_content(url: str, timeout: int = 30) -> str:
-    """Fetch content from a URL and extract readable text."""
+    """Fetch content from a URL and extract readable text.
+
+    Side effect: populates module-level _LAST_FETCH_METRICS with quality signals
+    (extracted_chars, has_article_tag, has_main_tag, title_len, fetcher) so that
+    the caller in main() can decide whether to warn or trigger a Playwright
+    fallback (see --auto-fallback-playwright).
+    """
+    global _LAST_FETCH_METRICS
+    _LAST_FETCH_METRICS = {
+        'extracted_chars': 0,
+        'has_article_tag': False,
+        'has_main_tag': False,
+        'title_len': 0,
+        'fetcher': 'curl+bs4',
+        'url': url,
+    }
+
     try:
         logging.info(f"Fetching content from URL: {url}")
 
@@ -49,27 +159,68 @@ def fetch_url_content(url: str, timeout: int = 30) -> str:
         if result.returncode != 0:
             raise requests.exceptions.RequestException(f"curl exit code {result.returncode}: {result.stderr.decode()[:200]}")
         html_bytes = result.stdout
-        
+
         logging.info(f"Successfully fetched {len(html_bytes)} bytes from URL")
 
         # Parse HTML content
         soup = BeautifulSoup(html_bytes, 'html.parser')
-        
+
+        # Layer 1 metrics: capture structural signals BEFORE stripping script/style.
+        _LAST_FETCH_METRICS['has_article_tag'] = soup.find('article') is not None
+        _LAST_FETCH_METRICS['has_main_tag'] = soup.find('main') is not None
+        title_tag = soup.find('title')
+        _LAST_FETCH_METRICS['title_len'] = len(title_tag.get_text(strip=True)) if title_tag else 0
+
         # Remove script and style elements
         for script in soup(["script", "style"]):
             script.decompose()
-        
+
         # Extract text content
         text = soup.get_text()
-        
+
         # Clean up whitespace
         lines = (line.strip() for line in text.splitlines())
         chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
         text = ' '.join(chunk for chunk in chunks if chunk)
-        
+
         logging.info(f"Extracted {len(text)} characters of text content")
+        _LAST_FETCH_METRICS['extracted_chars'] = len(text)
+        logging.info(
+            f"Fetch metrics: extracted_chars={_LAST_FETCH_METRICS['extracted_chars']}, "
+            f"article_tag={_LAST_FETCH_METRICS['has_article_tag']}, "
+            f"main_tag={_LAST_FETCH_METRICS['has_main_tag']}, "
+            f"title_len={_LAST_FETCH_METRICS['title_len']}"
+        )
+
+        # Layer 1: warn early when extraction is suspiciously thin.
+        if len(text) < FETCH_QUALITY_MIN_CHARS:
+            _emit_fetch_quality_warning(url, _LAST_FETCH_METRICS)
+
+            # Optional: auto-retry via Playwright when the user opts in.
+            if _AUTO_FALLBACK_PLAYWRIGHT:
+                print(
+                    f"INFO: --auto-fallback-playwright set; retrying {url} with Playwright",
+                    file=sys.stderr,
+                )
+                pw_text, pw_metrics = fetch_url_content_playwright(url)
+                # Only swap in the Playwright result if it actually improves things.
+                if pw_metrics.get('extracted_chars', 0) > len(text) and not pw_text.startswith('[ERROR'):
+                    _LAST_FETCH_METRICS = pw_metrics
+                    print(
+                        f"INFO: Playwright fetch recovered {pw_metrics['extracted_chars']} chars "
+                        f"(BS4 had {len(text)})",
+                        file=sys.stderr,
+                    )
+                    return pw_text
+                else:
+                    print(
+                        "WARN: Playwright fallback did not yield better content; "
+                        "keeping BS4 result",
+                        file=sys.stderr,
+                    )
+
         return text
-        
+
     except (TimeoutError, subprocess.TimeoutExpired):
         error_msg = f"Error fetching URL {url}: total timeout after {timeout}s"
         logging.error(error_msg)
@@ -522,8 +673,21 @@ def main():
     parser.add_argument('--disable-context-cache', action='store_true',
                        help='Disable explicit context caching')
     parser.add_argument('--output', '-o', help='Output file path (if not specified, output to stdout)')
+    parser.add_argument(
+        '--auto-fallback-playwright',
+        action='store_true',
+        help='If BS4 extracts less than %d chars, automatically retry the fetch '
+             'via Playwright (handles JS-rendered pages). Off by default.'
+             % FETCH_QUALITY_MIN_CHARS,
+    )
 
     args = parser.parse_args()
+
+    # Wire the CLI flag into the module-level fallback toggle so fetch_url_content
+    # (called indirectly via the template processor) can react to it.
+    if args.auto_fallback_playwright:
+        global _AUTO_FALLBACK_PLAYWRIGHT
+        _AUTO_FALLBACK_PLAYWRIGHT = True
 
     # Get script directory (needed for relative paths)
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/scripts/summary_review.py
+++ b/scripts/summary_review.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Post-generation review table for Gemini summaries (Issue #108, Layer 2).
+
+Scans a directory of v1.0 JSON summary files and prints a compact table:
+
+    ID  | Domain              | Title                          | One-Sentence Summary
+    001 | github.com          | GitHub Copilot の新機能...        | GitHub Copilotが...
+    164 | tokenstree.com      | TokensTree: 自律型AIエージェント...  | AIエージェント同士が...  <- suspicious
+
+Suspicious rows are flagged when the generated summary "smells like" a guess
+made from the domain rather than from the article body. Heuristics:
+
+  * Summary describes a site/service rather than an article — the text mentions
+    "プラットフォーム / platform / サービス / service / 企業 / company" without
+    any specific event, release, or finding.
+  * Title is generic: just the domain stem, just a company name, or extremely
+    short (< 12 characters of meaningful content).
+  * Title and one-sentence summary share unusually heavy domain-name overlap.
+
+This is a heuristic — it surfaces candidates for human review, not a
+hard reject. Use Layer 3 (re-summarize skill) to fix flagged entries.
+
+Usage:
+    uv run scripts/summary_review.py workdesk/summaries/
+    uv run scripts/summary_review.py journals/2026-04-18/summaries/
+    uv run scripts/summary_review.py workdesk/summaries/ --only-suspicious
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+# Heuristic vocabulary: words that, when present without a specific event,
+# suggest the summary is describing a service/site rather than an article.
+SITE_DESCRIPTOR_KEYWORDS = (
+    "プラットフォーム",
+    "platform",
+    "サービス",
+    "service",
+    "企業",
+    "company",
+    "ソリューション",
+    "solution",
+    "ベンチャー",
+    "startup",
+    "提供しています",
+    "提供する企業",
+)
+
+# Words that indicate an actual event/release/finding — their presence
+# downgrades the "site-descriptor" signal.
+EVENT_KEYWORDS = (
+    "発表",
+    "リリース",
+    "公開",
+    "ローンチ",
+    "launched",
+    "released",
+    "announced",
+    "introduces",
+    "introducing",
+    "公開しました",
+    "発表しました",
+    "提唱",
+    "報告",
+    "解説",
+    "明らかに",
+    "判明",
+    "示した",
+    "述べている",
+    "論じている",
+    "version",
+    "v1.",
+    "v2.",
+    "v3.",
+    "アップデート",
+    "新機能",
+    "new feature",
+    "blog post",
+    "記事",
+    "ブログ",
+    "ガイド",
+    "tutorial",
+    "チュートリアル",
+)
+
+
+def _domain_for(url: str) -> str:
+    try:
+        host = urlparse(url).netloc or url
+    except Exception:
+        host = url
+    return host.replace("www.", "")
+
+
+def _domain_stem(domain: str) -> str:
+    """Return the second-level label of a hostname (e.g. github.com -> github)."""
+    parts = domain.split(".")
+    if len(parts) >= 2:
+        return parts[-2].lower()
+    return domain.lower()
+
+
+def _truncate(text: str, width: int) -> str:
+    text = (text or "").strip().replace("\n", " ")
+    if len(text) <= width:
+        return text
+    return text[: max(0, width - 1)] + "…"
+
+
+def _load_summary(path: Path) -> Optional[Dict[str, Any]]:
+    """Load a v1.0 JSON summary file. Returns None on parse error."""
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _looks_like_site_description(one_sentence: str, summary_body: str) -> bool:
+    """True when the summary describes a site/service rather than an article."""
+    blob = f"{one_sentence}\n{summary_body}"
+    blob_lower = blob.lower()
+
+    has_descriptor = any(kw.lower() in blob_lower for kw in SITE_DESCRIPTOR_KEYWORDS)
+    has_event = any(kw.lower() in blob_lower for kw in EVENT_KEYWORDS)
+
+    # Site-descriptor language without a concrete event/release is the danger zone.
+    return has_descriptor and not has_event
+
+
+def _title_looks_generic(title: str, domain: str) -> bool:
+    """True when the title doesn't carry article-specific content."""
+    if not title:
+        return True
+    cleaned = title.strip()
+    if len(cleaned) < 12:
+        return True
+
+    stem = _domain_stem(domain)
+    if not stem:
+        return False
+
+    # Exact "GitHub" or "TokensTree" as title with nothing else is a red flag.
+    # Heuristic: title is mostly the domain stem if removing it leaves <8 chars.
+    pattern = re.compile(re.escape(stem), re.IGNORECASE)
+    leftover = pattern.sub("", cleaned).strip(" :：-—–|・,.")
+    if len(leftover) < 8:
+        return True
+
+    return False
+
+
+def evaluate_suspicion(content: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    """Score a summary's content. Returns (is_suspicious, reasons)."""
+    reasons: List[str] = []
+
+    title = content.get("title", "") or ""
+    one_sentence = content.get("oneSentenceSummary", "") or ""
+    summary_body = content.get("summaryBody", "") or ""
+    url = content.get("url", "") or ""
+    domain = _domain_for(url)
+
+    if _title_looks_generic(title, domain):
+        reasons.append("generic-title")
+
+    if _looks_like_site_description(one_sentence, summary_body):
+        reasons.append("site-descriptor")
+
+    # Very short summary body is another tell (Gemini gave up early).
+    # The schema enforces >= 100 chars but anything below ~200 is worth a look.
+    if 0 < len(summary_body) < 200:
+        reasons.append("short-body")
+
+    return (len(reasons) > 0, reasons)
+
+
+def gather_rows(directory: Path) -> List[Dict[str, Any]]:
+    """Scan a directory of summary JSON files and return per-file rows."""
+    rows: List[Dict[str, Any]] = []
+
+    if not directory.exists():
+        print(f"ERROR: {directory} does not exist", file=sys.stderr)
+        return rows
+
+    files = sorted(directory.glob("[0-9][0-9][0-9]_*.json"))
+
+    for path in files:
+        try:
+            file_id = int(path.name[:3])
+        except ValueError:
+            continue
+
+        data = _load_summary(path)
+        if data is None:
+            rows.append({
+                "id": file_id,
+                "domain": "(unparseable)",
+                "title": path.name,
+                "one_sentence": "",
+                "suspicious": True,
+                "reasons": ["json-parse-error"],
+                "path": str(path),
+            })
+            continue
+
+        content = data.get("content", {}) or {}
+        url = content.get("url", "") or ""
+        domain = _domain_for(url)
+
+        suspicious, reasons = evaluate_suspicion(content)
+
+        rows.append({
+            "id": file_id,
+            "domain": domain,
+            "title": content.get("title", "") or "",
+            "one_sentence": content.get("oneSentenceSummary", "") or "",
+            "suspicious": suspicious,
+            "reasons": reasons,
+            "path": str(path),
+        })
+
+    return rows
+
+
+def render_table(
+    rows: List[Dict[str, Any]],
+    *,
+    only_suspicious: bool = False,
+    domain_width: int = 24,
+    title_width: int = 36,
+    summary_width: int = 60,
+) -> str:
+    """Render the table as a single string."""
+    if only_suspicious:
+        rows = [r for r in rows if r["suspicious"]]
+
+    if not rows:
+        return "(no rows)"
+
+    header = (
+        f"{'ID':<4}| {'Domain':<{domain_width}}| "
+        f"{'Title':<{title_width}}| {'One-Sentence Summary':<{summary_width}}"
+    )
+    separator = "-" * len(header)
+    out_lines: List[str] = [header, separator]
+
+    for r in rows:
+        marker = "  <- suspicious" if r["suspicious"] else ""
+        line = (
+            f"{r['id']:03d} | "
+            f"{_truncate(r['domain'], domain_width - 1):<{domain_width - 1}} | "
+            f"{_truncate(r['title'], title_width - 1):<{title_width - 1}} | "
+            f"{_truncate(r['one_sentence'], summary_width)}"
+            f"{marker}"
+        )
+        out_lines.append(line)
+        if r["suspicious"] and r["reasons"]:
+            out_lines.append(f"     reasons: {', '.join(r['reasons'])}")
+
+    out_lines.append("")
+    suspicious_count = sum(1 for r in rows if r["suspicious"])
+    out_lines.append(
+        f"Total: {len(rows)} rows, {suspicious_count} flagged for review"
+    )
+    return "\n".join(out_lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print a review table for generated JSON summaries (Issue #108, Layer 2)"
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="workdesk/summaries",
+        help="Directory of XXX_*.json summary files (default: workdesk/summaries)",
+    )
+    parser.add_argument(
+        "--only-suspicious",
+        action="store_true",
+        help="Show only rows the heuristics flagged for review",
+    )
+
+    args = parser.parse_args()
+    directory = Path(args.directory)
+
+    rows = gather_rows(directory)
+    if not rows:
+        print(f"(no summary files found in {directory})", file=sys.stderr)
+        return 1
+
+    print(render_table(rows, only_suspicious=args.only_suspicious))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements Layers 1–3 of #108 to detect and prevent the recurring "wrong Gemini summary" problem (15+ historical manual fixes). When BeautifulSoup fails silently on JS-rendered pages, Gemini fabricates a plausible-but-incorrect summary from the URL/domain (the canonical example being #164 tokenstree.com). These changes add detection at fetch time, surface candidates for human review post-batch, and document the retry workflow.

## Layer 1 — Fetch quality gate (`scripts/call-gemini.py`)

- Captures structural metrics during BS4 extraction: `extracted_chars`, `has_article_tag`, `has_main_tag`, `title_len`.
- Emits a stderr `WARN: extracted only N chars from <url>; summary may be unreliable` when extraction is below 200 chars.
- Adds opt-in `--auto-fallback-playwright` flag: when content is below the threshold and the flag is set, automatically retries the fetch via the in-process Playwright integration (Chromium headless, with a `networkidle` settle window). Off by default — explicit flag only, as the issue specified.
- The Playwright fallback only swaps in the rendered result if it is materially better than what BS4 produced; otherwise the BS4 text is kept.
- The existing inline schema validation in this file is left untouched, per the heads-up about #113 in flight.

## Layer 2 — Post-generation review table (`scripts/summary_review.py`, new)

A standalone reviewer that scans a directory of v1.0 JSON summary files and prints a compact table:

```
ID  | Domain              | Title                          | One-Sentence Summary
001 | zenn.dev            | 入社1週目で即戦力になれた理由...    | クラシルのiOSチームにおいて...
164 | tokenstree.com      | TokensTree: 自律型AIエージェント... | AIエージェント同士が...      <- suspicious
     reasons: site-descriptor, generic-title
```

Heuristics that flag a row:

- **`site-descriptor`** — summary mentions プラットフォーム / platform / サービス / etc. without any concrete event/release/finding keyword (発表 / リリース / launched / introducing / version / etc.).
- **`generic-title`** — title is mostly the domain stem with little remaining after substitution.
- **`short-body`** — `summaryBody` just clears the schema floor (< 200 chars).
- **`json-parse-error`** — file failed to parse.

`scripts/bulk_summarize.py` gains `--review-table` to render the same table after a batch run (or stand-alone when there are no unchecked URLs). Imports `summary_review` lazily so older trees keep working.

## Layer 3 — Retry workflow (`.claude/skills/summarize-source/SKILL.md`)

Adds a focused new section **`## Batch retry with Playwright`** that documents both retry paths:

- **Playwright MCP** for manual rendered-text capture (preferred for inspection-heavy fixes).
- **`--auto-fallback-playwright` CLI** for the simpler one-shot path landed in Layer 1.

Section is self-contained to minimize merge conflict with #99, which is editing trigger phrases in the same file.

## Intentionally skipped

- **Layer 4 (LLM coherence check)** — deferred per the issue's priority guidance.
- **Validator extraction (#113)** — left the existing inline `validate_json_summary` alone; the two PRs may need a small merge resolution, as expected.

## Test plan

- [x] `uv run scripts/call-gemini.py --url <healthy-URL>` emits no Layer 1 warning (verified with zenn.dev/dely_jp/articles/bfc7aed2c10d3c → extracted 5270 chars, no `WARN:` line in stderr; the only stderr output is the pre-existing URL-mismatch correction).
- [x] `uv run scripts/call-gemini.py --url <thin-JS-page>` does emit the Layer 1 warning (verified with `https://qwen.ai/blog?id=qwen3.6` from the #251 fix commit → BS4 extracts 4 chars, warning fires with full diagnostic context).
- [x] `--auto-fallback-playwright` recovers content (verified on the same qwen.ai URL: BS4 = 4 chars → Playwright = 28,491 chars, fetcher swaps to `playwright` in the metrics).
- [x] `uv run scripts/summary_review.py journals/2026-04-18/summaries/` produces sensible output over 262 real summaries (16 flagged; spot-checked flags are reasonable candidates for human review, e.g. #168 actually is a service-overview entry).
- [x] `uv run scripts/bulk_summarize.py --review-table` works end-to-end (workdesk is empty post-cycle as the issue noted, but the integration path runs cleanly and prints `(no summary files found in ...)` in that case).

## Scope discipline

Touched only:

- `scripts/call-gemini.py` (Layer 1)
- `scripts/bulk_summarize.py` (Layer 2 wiring)
- `scripts/summary_review.py` (Layer 2, new file)
- `.claude/skills/summarize-source/SKILL.md` (Layer 3, new section only)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)