### PR TITLE
feat: clickable ID badge web component (#95)

### DIFF
--- a/website/public/js/web-components.js
+++ b/website/public/js/web-components.js
@@ -370,6 +370,244 @@ class MarkdownRenderer extends HTMLElement {
 }
 
 /**
+ * CopyableId Web Component
+ *
+ * Renders an article ID badge (e.g. "#001") as a clickable inline element.
+ * On click, the ID (with the leading "#") is copied to the clipboard and a
+ * brief Japanese tooltip ("コピーしました!") is shown via the
+ * :host(.copied) state for ~1.5 seconds.
+ */
+const copyableIdTemplateHTML = `
+  <style>
+    :host {
+      display: inline-flex;
+      align-items: center;
+      position: relative;
+      cursor: pointer;
+      user-select: none;
+      -webkit-user-select: none;
+      font-weight: 600;
+      color: inherit;
+      transition: color 0.15s ease, background-color 0.15s ease;
+    }
+
+    :host(:hover) .badge {
+      color: var(--copyable-id-hover-color, #2563eb);
+    }
+
+    :host(:focus-visible) {
+      outline: 2px solid var(--color-primary, #2563eb);
+      outline-offset: 2px;
+      border-radius: 0.25rem;
+    }
+
+    .badge {
+      display: inline-block;
+      transition: color 0.15s ease;
+      font: inherit;
+      color: inherit;
+      background: transparent;
+    }
+
+    .tooltip {
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 50%;
+      transform: translateX(-50%) translateY(4px);
+      padding: 0.25rem 0.5rem;
+      background-color: var(--copyable-id-tooltip-bg, #1f2937);
+      color: var(--copyable-id-tooltip-color, #ffffff);
+      font-size: 0.75rem;
+      font-weight: 500;
+      line-height: 1;
+      white-space: nowrap;
+      border-radius: 0.25rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease, transform 0.15s ease;
+      z-index: 10;
+    }
+
+    .tooltip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 4px solid transparent;
+      border-top-color: var(--copyable-id-tooltip-bg, #1f2937);
+    }
+
+    :host(.copied) .tooltip {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+  </style>
+
+  <span class="badge" part="badge"></span>
+  <span class="tooltip" role="status" aria-live="polite">コピーしました!</span>
+`;
+
+class CopyableId extends HTMLElement {
+  constructor() {
+    super();
+
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = copyableIdTemplateHTML;
+
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
+
+    this.badgeEl = this.shadowRoot.querySelector('.badge');
+
+    this._onClick = this._onClick.bind(this);
+    this._onKeydown = this._onKeydown.bind(this);
+
+    this._resetTimer = null;
+  }
+
+  static get observedAttributes() {
+    return ['value'];
+  }
+
+  connectedCallback() {
+    if (typeof document === 'undefined') return;
+
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '0');
+    }
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'button');
+    }
+    this._updateAriaLabel();
+
+    this._renderValue();
+
+    this.addEventListener('click', this._onClick);
+    this.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this._onClick);
+    this.removeEventListener('keydown', this._onKeydown);
+    if (this._resetTimer) {
+      clearTimeout(this._resetTimer);
+      this._resetTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name) {
+    if (name === 'value') {
+      this._renderValue();
+      this._updateAriaLabel();
+    }
+  }
+
+  get _id() {
+    const explicit = this.getAttribute('value');
+    const raw = (explicit ?? this.textContent ?? '').trim();
+    return raw.startsWith('#') ? raw.slice(1) : raw;
+  }
+
+  get _copyText() {
+    return `#${this._id}`;
+  }
+
+  _renderValue() {
+    if (!this.badgeEl) return;
+    this.badgeEl.textContent = this._copyText;
+  }
+
+  _updateAriaLabel() {
+    this.setAttribute('aria-label', `${this._copyText} をコピー`);
+  }
+
+  _onClick(event) {
+    event.preventDefault();
+    this._copyToClipboard();
+  }
+
+  _onKeydown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this._copyToClipboard();
+    }
+  }
+
+  async _copyToClipboard() {
+    const text = this._copyText;
+    let succeeded = false;
+
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        succeeded = true;
+      } catch (err) {
+        console.warn('navigator.clipboard.writeText failed, using fallback:', err);
+      }
+    }
+
+    if (!succeeded) {
+      succeeded = this._execCommandFallback(text);
+    }
+
+    if (succeeded) {
+      this._showCopiedFeedback();
+      this.dispatchEvent(new CustomEvent('copyable-id:copied', {
+        bubbles: true,
+        composed: true,
+        detail: { value: text },
+      }));
+    } else {
+      console.warn('CopyableId: failed to copy to clipboard');
+      this.dispatchEvent(new CustomEvent('copyable-id:copy-failed', {
+        bubbles: true,
+        composed: true,
+        detail: { value: text },
+      }));
+    }
+  }
+
+  _execCommandFallback(text) {
+    if (typeof document === 'undefined') return false;
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.top = '0';
+      textarea.style.left = '0';
+      textarea.style.opacity = '0';
+      textarea.style.pointerEvents = 'none';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const ok = document.execCommand && document.execCommand('copy');
+      document.body.removeChild(textarea);
+      return !!ok;
+    } catch (err) {
+      console.warn('execCommand copy fallback failed:', err);
+      return false;
+    }
+  }
+
+  _showCopiedFeedback() {
+    this.classList.add('copied');
+    if (this._resetTimer) {
+      clearTimeout(this._resetTimer);
+    }
+    this._resetTimer = setTimeout(() => {
+      this.classList.remove('copied');
+      this._resetTimer = null;
+    }, 1500);
+  }
+}
+
+/**
  * Register a web component with error handling
  * @param {string} tagName - The custom element tag name
  * @param {typeof HTMLElement} componentClass - The web component class
@@ -381,7 +619,7 @@ function registerComponent(tagName, componentClass) {
       console.warn(`Web component "${tagName}" is already registered`);
       return;
     }
-    
+
     customElements.define(tagName, componentClass);
     console.log(`✅ Registered web component: ${tagName}`);
   } catch (error) {
@@ -394,6 +632,7 @@ function registerComponent(tagName, componentClass) {
  */
 function registerAllComponents() {
   registerComponent('markdown-renderer', MarkdownRenderer);
+  registerComponent('copyable-id', CopyableId);
 }
 
 /**
@@ -403,15 +642,22 @@ function registerMarkdownRenderer() {
   registerComponent('markdown-renderer', MarkdownRenderer);
 }
 
+function registerCopyableId() {
+  registerComponent('copyable-id', CopyableId);
+}
+
 // Export functions for module usage
 window.WebComponents = {
   registerAllComponents,
   registerMarkdownRenderer,
-  MarkdownRenderer
+  registerCopyableId,
+  MarkdownRenderer,
+  CopyableId
 };
 
 // Auto-register for script tag usage
 if (typeof module === 'undefined') {
   // Running as script tag, auto-register
   registerMarkdownRenderer();
+  registerCopyableId();
 }

--- a/website/src/components/WorkdeskSidebar.astro
+++ b/website/src/components/WorkdeskSidebar.astro
@@ -50,7 +50,7 @@ function formatDate(date: Date): string {
           <article class="summary-item">
             <div class="summary-header">
               <h3 class="summary-title">
-                <span class="summary-number">#{summary.id}</span>
+                <copyable-id class="summary-number" value={summary.id}>{summary.id}</copyable-id>
                 <a href={withBase(`/journals/${nextJournalDate}/${summary.id}/`)}>
                   {summary.title}
                 </a>
@@ -419,3 +419,46 @@ function formatDate(date: Date): string {
     }
   }
 </style>
+
+<script type="module" is:inline define:vars={{ webComponentsUrl: withBase('/js/web-components.js') }}>
+  // Register the copyable-id web component used by ID badges in the sidebar.
+  async function initializeComponents() {
+    try {
+      try {
+        const module = await import(webComponentsUrl);
+        if (module.registerCopyableId) {
+          module.registerCopyableId();
+        } else if (module.registerAllComponents) {
+          module.registerAllComponents();
+        } else if (window.WebComponents?.registerCopyableId) {
+          window.WebComponents.registerCopyableId();
+        }
+        console.log('✅ copyable-id registered (sidebar)');
+      } catch (moduleError) {
+        console.warn('Module import failed, trying global approach:', moduleError);
+
+        if (window.WebComponents?.registerCopyableId) {
+          window.WebComponents.registerCopyableId();
+        } else {
+          const script = document.createElement('script');
+          script.src = webComponentsUrl;
+          script.type = 'module';
+          script.onload = () => {
+            if (window.WebComponents?.registerCopyableId) {
+              window.WebComponents.registerCopyableId();
+            }
+          };
+          document.head.appendChild(script);
+        }
+      }
+    } catch (error) {
+      console.warn('⚠️ copyable-id failed to load:', error);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeComponents);
+  } else {
+    initializeComponents();
+  }
+</script>

--- a/website/src/components/web-components/CopyableId.js
+++ b/website/src/components/web-components/CopyableId.js
@@ -1,0 +1,264 @@
+/**
+ * CopyableId Web Component
+ *
+ * Renders an article ID badge (e.g. "#001") as a clickable inline element.
+ * On click, the ID (with the leading "#") is copied to the clipboard and a
+ * brief Japanese tooltip ("コピーしました!") is shown via the
+ * :host(.copied) state for ~1.5 seconds.
+ *
+ * Usage:
+ *   <copyable-id>001</copyable-id>
+ *   <copyable-id value="042" variant="badge">042</copyable-id>
+ *
+ * The textContent is treated as the ID. A leading "#" in the textContent is
+ * stripped so callers can pass either "001" or "#001" without breaking the
+ * copied value (which is always prefixed with exactly one "#").
+ */
+
+const templateHTML = `
+  <style>
+    :host {
+      /* Inline so the badge sits inside text or flex rows naturally. */
+      display: inline-flex;
+      align-items: center;
+      position: relative;
+      cursor: pointer;
+      user-select: none;
+      -webkit-user-select: none;
+      font-weight: 600;
+      color: inherit;
+      /* Subtle affordance that this is interactive. */
+      transition: color 0.15s ease, background-color 0.15s ease;
+    }
+
+    :host(:hover) .badge {
+      color: var(--copyable-id-hover-color, #2563eb);
+    }
+
+    :host(:focus-visible) {
+      outline: 2px solid var(--color-primary, #2563eb);
+      outline-offset: 2px;
+      border-radius: 0.25rem;
+    }
+
+    .badge {
+      display: inline-block;
+      transition: color 0.15s ease;
+      /* Inherit typography and colors from the surrounding context so that
+         external host styling (e.g. background, padding, border) governs the
+         visual appearance and the inner badge stays transparent. */
+      font: inherit;
+      color: inherit;
+      background: transparent;
+    }
+
+    .tooltip {
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 50%;
+      transform: translateX(-50%) translateY(4px);
+      padding: 0.25rem 0.5rem;
+      background-color: var(--copyable-id-tooltip-bg, #1f2937);
+      color: var(--copyable-id-tooltip-color, #ffffff);
+      font-size: 0.75rem;
+      font-weight: 500;
+      line-height: 1;
+      white-space: nowrap;
+      border-radius: 0.25rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease, transform 0.15s ease;
+      z-index: 10;
+    }
+
+    .tooltip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 4px solid transparent;
+      border-top-color: var(--copyable-id-tooltip-bg, #1f2937);
+    }
+
+    :host(.copied) .tooltip {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+  </style>
+
+  <span class="badge" part="badge"></span>
+  <span class="tooltip" role="status" aria-live="polite">コピーしました!</span>
+`;
+
+class CopyableId extends HTMLElement {
+  constructor() {
+    super();
+
+    if (typeof document === 'undefined') {
+      // SSR safety: do nothing when there is no DOM.
+      return;
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = templateHTML;
+
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(template.content.cloneNode(true));
+
+    this.badgeEl = this.shadowRoot.querySelector('.badge');
+
+    // Bound handlers so we can detach them later if needed.
+    this._onClick = this._onClick.bind(this);
+    this._onKeydown = this._onKeydown.bind(this);
+
+    this._resetTimer = null;
+  }
+
+  static get observedAttributes() {
+    return ['value'];
+  }
+
+  connectedCallback() {
+    if (typeof document === 'undefined') return;
+
+    // Make the element keyboard-focusable and announce its role.
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '0');
+    }
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'button');
+    }
+    this._updateAriaLabel();
+
+    this._renderValue();
+
+    this.addEventListener('click', this._onClick);
+    this.addEventListener('keydown', this._onKeydown);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this._onClick);
+    this.removeEventListener('keydown', this._onKeydown);
+    if (this._resetTimer) {
+      clearTimeout(this._resetTimer);
+      this._resetTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name) {
+    if (name === 'value') {
+      this._renderValue();
+      this._updateAriaLabel();
+    }
+  }
+
+  /**
+   * The raw ID string, without the leading "#".
+   */
+  get _id() {
+    const explicit = this.getAttribute('value');
+    const raw = (explicit ?? this.textContent ?? '').trim();
+    return raw.startsWith('#') ? raw.slice(1) : raw;
+  }
+
+  /**
+   * The string copied to the clipboard. Always exactly one "#" prefix.
+   */
+  get _copyText() {
+    return `#${this._id}`;
+  }
+
+  _renderValue() {
+    if (!this.badgeEl) return;
+    this.badgeEl.textContent = this._copyText;
+  }
+
+  _updateAriaLabel() {
+    this.setAttribute('aria-label', `${this._copyText} をコピー`);
+  }
+
+  _onClick(event) {
+    event.preventDefault();
+    this._copyToClipboard();
+  }
+
+  _onKeydown(event) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this._copyToClipboard();
+    }
+  }
+
+  async _copyToClipboard() {
+    const text = this._copyText;
+    let succeeded = false;
+
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        succeeded = true;
+      } catch (err) {
+        // Fall through to execCommand fallback.
+        console.warn('navigator.clipboard.writeText failed, using fallback:', err);
+      }
+    }
+
+    if (!succeeded) {
+      succeeded = this._execCommandFallback(text);
+    }
+
+    if (succeeded) {
+      this._showCopiedFeedback();
+      this.dispatchEvent(new CustomEvent('copyable-id:copied', {
+        bubbles: true,
+        composed: true,
+        detail: { value: text },
+      }));
+    } else {
+      console.warn('CopyableId: failed to copy to clipboard');
+      this.dispatchEvent(new CustomEvent('copyable-id:copy-failed', {
+        bubbles: true,
+        composed: true,
+        detail: { value: text },
+      }));
+    }
+  }
+
+  _execCommandFallback(text) {
+    if (typeof document === 'undefined') return false;
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      // Avoid scrolling to bottom and keep it off-screen.
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'fixed';
+      textarea.style.top = '0';
+      textarea.style.left = '0';
+      textarea.style.opacity = '0';
+      textarea.style.pointerEvents = 'none';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      const ok = document.execCommand && document.execCommand('copy');
+      document.body.removeChild(textarea);
+      return !!ok;
+    } catch (err) {
+      console.warn('execCommand copy fallback failed:', err);
+      return false;
+    }
+  }
+
+  _showCopiedFeedback() {
+    this.classList.add('copied');
+    if (this._resetTimer) {
+      clearTimeout(this._resetTimer);
+    }
+    this._resetTimer = setTimeout(() => {
+      this.classList.remove('copied');
+      this._resetTimer = null;
+    }, 1500);
+  }
+}
+
+export { CopyableId };

--- a/website/src/components/web-components/index.js
+++ b/website/src/components/web-components/index.js
@@ -4,6 +4,7 @@
  */
 
 import { MarkdownRenderer } from './MarkdownRenderer.js';
+import { CopyableId } from './CopyableId.js';
 
 /**
  * Register a web component with error handling
@@ -17,7 +18,7 @@ function registerComponent(tagName, componentClass) {
       console.warn(`Web component "${tagName}" is already registered`);
       return;
     }
-    
+
     customElements.define(tagName, componentClass);
     console.log(`✅ Registered web component: ${tagName}`);
   } catch (error) {
@@ -30,6 +31,7 @@ function registerComponent(tagName, componentClass) {
  */
 export function registerAllComponents() {
   registerComponent('markdown-renderer', MarkdownRenderer);
+  registerComponent('copyable-id', CopyableId);
 }
 
 /**
@@ -37,6 +39,10 @@ export function registerAllComponents() {
  */
 export function registerMarkdownRenderer() {
   registerComponent('markdown-renderer', MarkdownRenderer);
+}
+
+export function registerCopyableId() {
+  registerComponent('copyable-id', CopyableId);
 }
 
 // Note: Auto-registration removed to prevent duplicate registrations.

--- a/website/src/pages/journals/[date]/[id].astro
+++ b/website/src/pages/journals/[date]/[id].astro
@@ -185,7 +185,7 @@ const nextSummary = currentIndex > 0
             {statusLabel}
           </div>
           <div class="summary-info">
-            <span class="summary-id">#{summary.id}</span>
+            <copyable-id class="summary-id" value={summary.id}>{summary.id}</copyable-id>
             <span class="summary-stats">{summary.wordCount.toLocaleString()}文字 • {summary.readingTime}分</span>
           </div>
         </div>
@@ -359,30 +359,39 @@ const nextSummary = currentIndex > 0
       
       try {
         const module = await import(webComponentsUrl);
-        if (module.registerMarkdownRenderer) {
-          module.registerMarkdownRenderer();
-        } else if (window.WebComponents?.registerMarkdownRenderer) {
-          window.WebComponents.registerMarkdownRenderer();
+        if (module.registerAllComponents) {
+          module.registerAllComponents();
+        } else {
+          if (module.registerMarkdownRenderer) {
+            module.registerMarkdownRenderer();
+          } else if (window.WebComponents?.registerMarkdownRenderer) {
+            window.WebComponents.registerMarkdownRenderer();
+          }
+          if (module.registerCopyableId) {
+            module.registerCopyableId();
+          } else if (window.WebComponents?.registerCopyableId) {
+            window.WebComponents.registerCopyableId();
+          }
         }
-        console.log('✅ Markdown renderer registered successfully');
+        console.log('✅ Web components registered successfully');
       } catch (moduleError) {
         console.warn('Module import failed, trying global approach:', moduleError);
-        
-        if (window.WebComponents?.registerMarkdownRenderer) {
-          window.WebComponents.registerMarkdownRenderer();
-          console.log('✅ Markdown renderer registered via global');
+
+        if (window.WebComponents?.registerAllComponents) {
+          window.WebComponents.registerAllComponents();
+          console.log('✅ Web components registered via global');
         } else {
           const script = document.createElement('script');
           script.src = webComponentsUrl;
           script.type = 'module';
-          
+
           script.onload = () => {
-            if (window.WebComponents?.registerMarkdownRenderer) {
-              window.WebComponents.registerMarkdownRenderer();
-              console.log('✅ Markdown renderer registered via script load');
+            if (window.WebComponents?.registerAllComponents) {
+              window.WebComponents.registerAllComponents();
+              console.log('✅ Web components registered via script load');
             }
           };
-          
+
           document.head.appendChild(script);
         }
       }

--- a/website/src/pages/journals/[date]/summaries.astro
+++ b/website/src/pages/journals/[date]/summaries.astro
@@ -149,7 +149,7 @@ const summariesByStatus = {
             {summariesByStatus.main.map(summary => (
               <article class="summary-card">
                 <header class="summary-header">
-                  <div class="summary-id">#{summary.id}</div>
+                  <copyable-id class="summary-id" value={summary.id}>{summary.id}</copyable-id>
                   <div class="summary-domain">
                     <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer">
                       {formatDomainDisplay(summary.sourceUrl)}
@@ -213,7 +213,7 @@ const summariesByStatus = {
             {summariesByStatus.annex.map(summary => (
               <article class="summary-card">
                 <header class="summary-header">
-                  <div class="summary-id">#{summary.id}</div>
+                  <copyable-id class="summary-id" value={summary.id}>{summary.id}</copyable-id>
                   <div class="summary-domain">
                     <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer">
                       {formatDomainDisplay(summary.sourceUrl)}
@@ -272,7 +272,7 @@ const summariesByStatus = {
             {summariesByStatus.omitted.map(summary => (
               <article class="summary-card">
                 <header class="summary-header">
-                  <div class="summary-id">#{summary.id}</div>
+                  <copyable-id class="summary-id" value={summary.id}>{summary.id}</copyable-id>
                   <div class="summary-domain">
                     <a href={summary.sourceUrl} target="_blank" rel="noopener noreferrer">
                       {formatDomainDisplay(summary.sourceUrl)}
@@ -347,37 +347,46 @@ const summariesByStatus = {
       // First try to import as module
       try {
         const module = await import(webComponentsUrl);
-        if (module.registerMarkdownRenderer) {
-          module.registerMarkdownRenderer();
-        } else if (window.WebComponents?.registerMarkdownRenderer) {
-          window.WebComponents.registerMarkdownRenderer();
+        if (module.registerAllComponents) {
+          module.registerAllComponents();
+        } else {
+          if (module.registerMarkdownRenderer) {
+            module.registerMarkdownRenderer();
+          } else if (window.WebComponents?.registerMarkdownRenderer) {
+            window.WebComponents.registerMarkdownRenderer();
+          }
+          if (module.registerCopyableId) {
+            module.registerCopyableId();
+          } else if (window.WebComponents?.registerCopyableId) {
+            window.WebComponents.registerCopyableId();
+          }
         }
-        console.log('✅ Markdown renderer component registered successfully via module import');
+        console.log('✅ Web components registered successfully via module import');
       } catch (moduleError) {
         // Fallback: load as script and use global
         console.warn('Module import failed, trying script tag approach:', moduleError);
-        
+
         // Check if already loaded globally
-        if (window.WebComponents?.registerMarkdownRenderer) {
-          window.WebComponents.registerMarkdownRenderer();
-          console.log('✅ Markdown renderer component registered successfully via global');
+        if (window.WebComponents?.registerAllComponents) {
+          window.WebComponents.registerAllComponents();
+          console.log('✅ Web components registered successfully via global');
         } else {
           // Load via script tag
           const script = document.createElement('script');
           script.src = webComponentsUrl;
           script.type = 'module';
-          
+
           script.onload = () => {
-            if (window.WebComponents?.registerMarkdownRenderer) {
-              window.WebComponents.registerMarkdownRenderer();
-              console.log('✅ Markdown renderer component registered successfully via script load');
+            if (window.WebComponents?.registerAllComponents) {
+              window.WebComponents.registerAllComponents();
+              console.log('✅ Web components registered successfully via script load');
             }
           };
-          
+
           script.onerror = () => {
             throw new Error('Failed to load web components script');
           };
-          
+
           document.head.appendChild(script);
         }
       }


### PR DESCRIPTION
## Summary

Adds a `<copyable-id>` web component that renders article ID badges (e.g. `#001`) as clickable elements. Clicking copies the ID with `#` prefix to the clipboard and shows a Japanese tooltip ("コピーしました!") for ~1.5 seconds via a `:host(.copied)` state. Falls back to `document.execCommand('copy')` when `navigator.clipboard` is unavailable.

## Files touched

- **New:** `website/src/components/web-components/CopyableId.js` — shadow-DOM web component with clipboard + tooltip + keyboard (Enter/Space) support, dispatches `copyable-id:copied` / `copyable-id:copy-failed` events
- `website/src/components/web-components/index.js` — register `copyable-id` in `registerAllComponents` and add `registerCopyableId` export
- `website/public/js/web-components.js` — bundled output with `CopyableId` class and registration helpers
- `website/src/components/WorkdeskSidebar.astro` — `<span class="summary-number">#{id}</span>` → `<copyable-id class="summary-number" value={id}>{id}</copyable-id>`; adds component-loading script (sidebar lives on the homepage which had no init script)
- `website/src/pages/journals/[date]/[id].astro` — `<span class="summary-id">` → `<copyable-id>`; init script now registers all components
- `website/src/pages/journals/[date]/summaries.astro` — three `<div class="summary-id">` → `<copyable-id>`; init script now registers all components

The original `class="summary-id"` / `class="summary-number"` are kept on the host element so existing CSS (typography, spacing, badge background in the sidebar) continues to apply unchanged. The shadow-DOM `.badge` is fully transparent (`font: inherit; color: inherit; background: transparent`) so the host's external styling governs the visual appearance.

## Branch note

The user-requested branch name `feat/copyable-id-component` was already checked out in another worktree with in-progress work, so this PR uses `feat/copyable-id-component-95` to avoid clobbering it. Functionality is unchanged.

## Test plan

- [x] `npm run build` succeeds (Astro check + build, 7858 pages built)
- [x] Bundled `public/js/web-components.js` contains the `CopyableId` class (verified via grep)
- [x] Built HTML uses `<copyable-id class="summary-id" value="135">135</copyable-id>` markup
- [x] **Browser smoke test (Playwright against `astro preview`):**
  - `customElements.get('copyable-id')` is defined on `/summaries/`, `/[id]/`, and homepage `/`
  - Shadow DOM renders `#001` correctly from `value="001"`
  - Clicking dispatches `navigator.clipboard.writeText("#001")` (verified via stub) — clipboard receives `#NNN` with the `#`
  - `.copied` class is added on click and the tooltip "コピーしました!" appears
  - `.copied` class is removed after 1.5s
  - `aria-label="#001 をコピー"`, `role="button"`, `tabindex="0"` set automatically
  - Same behavior verified on `/journals/[date]/[id]/` summary detail page (copies `#135`)
- [ ] Manual test: click a badge in a real browser, paste from clipboard to confirm OS-level copy (the Playwright test stubs `navigator.clipboard.writeText`, which validates the call but not the OS clipboard end-to-end)
- [ ] Manual keyboard test: tab to a badge and press Enter/Space

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)