### PR TITLE
fix(summarize): route SPA/JS-gated domains and guard hallucinated fetches

### DIFF
--- a/scripts/call-gemini.py
+++ b/scripts/call-gemini.py
@@ -26,6 +26,11 @@ def _timeout_handler(signum, frame):
 
 
 from modules.template_processor import process_template, parse_replacements
+from modules.fetch_router import (
+    needs_spa_render,
+    looks_blocked,
+    build_blocked_stub,
+)
 from validate_summary import validate as _validate_summary
 
 # Layer 1 (Issue #108) — Fetch quality gate
@@ -126,9 +131,17 @@ def fetch_url_content(url: str, timeout: int = 30) -> str:
     """Fetch content from a URL and extract readable text.
 
     Side effect: populates module-level _LAST_FETCH_METRICS with quality signals
-    (extracted_chars, has_article_tag, has_main_tag, title_len, fetcher) so that
-    the caller in main() can decide whether to warn or trigger a Playwright
-    fallback (see --auto-fallback-playwright).
+    (extracted_chars, has_article_tag, has_main_tag, title_len, fetcher,
+    blocked, blocked_reason, raw_bytes) so that the caller in main() can decide
+    whether to warn, trigger a Playwright fallback (see --auto-fallback-playwright),
+    or short-circuit and emit a blocked-stub instead of hallucinating a summary
+    (Issue #121).
+
+    Domain-aware routing (Issue #121): URLs whose host matches the SPA-render
+    allowlist (qwen.ai, *.notion.site, openai.com — but not
+    developers.openai.com) are routed through Playwright FIRST. If Playwright
+    is not importable, the SPA path falls through to curl + the generic
+    blocked-content guard, which will emit a stub rather than hallucinate.
     """
     global _LAST_FETCH_METRICS
     _LAST_FETCH_METRICS = {
@@ -138,7 +151,35 @@ def fetch_url_content(url: str, timeout: int = 30) -> str:
         'title_len': 0,
         'fetcher': 'curl+bs4',
         'url': url,
+        'raw_bytes': 0,
+        'blocked': False,
+        'blocked_reason': '',
     }
+
+    # Issue #121: route SPA / JS-gated domains through Playwright up front.
+    # If Playwright is not available the curl path will run and the guard
+    # below will catch the resulting interstitial/SPA-shell.
+    if needs_spa_render(url):
+        try:
+            import playwright  # noqa: F401  (probe whether the dep is installed)
+            logging.info(f"Routing {url} through Playwright (SPA-render allowlist)")
+            pw_text, pw_metrics = fetch_url_content_playwright(url, timeout=timeout)
+            _LAST_FETCH_METRICS.update(pw_metrics)
+            _LAST_FETCH_METRICS['url'] = url
+            blocked, reason = looks_blocked(pw_text if not pw_text.startswith('[ERROR') else '')
+            if blocked:
+                _LAST_FETCH_METRICS['blocked'] = True
+                _LAST_FETCH_METRICS['blocked_reason'] = reason
+                print(
+                    f"WARN: Playwright fetch for {url} still looks blocked: {reason}",
+                    file=sys.stderr,
+                )
+            return pw_text
+        except ImportError:
+            logging.warning(
+                f"Playwright not importable; SPA host {url} will be tried via curl "
+                "and the blocked-content guard will likely fire."
+            )
 
     try:
         logging.info(f"Fetching content from URL: {url}")
@@ -160,6 +201,7 @@ def fetch_url_content(url: str, timeout: int = 30) -> str:
         if result.returncode != 0:
             raise requests.exceptions.RequestException(f"curl exit code {result.returncode}: {result.stderr.decode()[:200]}")
         html_bytes = result.stdout
+        _LAST_FETCH_METRICS['raw_bytes'] = len(html_bytes)
 
         logging.info(f"Successfully fetched {len(html_bytes)} bytes from URL")
 
@@ -193,6 +235,20 @@ def fetch_url_content(url: str, timeout: int = 30) -> str:
             f"title_len={_LAST_FETCH_METRICS['title_len']}"
         )
 
+        # Issue #121: blocked-content guard. Catches anti-bot interstitials
+        # (e.g. openai.com/index/*) and un-hydrated SPA shells regardless of
+        # whether the URL was routed through Playwright. Records the verdict
+        # in the module-level metrics so main() can short-circuit before the
+        # LLM call.
+        blocked, blocked_reason = looks_blocked(text)
+        if blocked:
+            _LAST_FETCH_METRICS['blocked'] = True
+            _LAST_FETCH_METRICS['blocked_reason'] = blocked_reason
+            print(
+                f"WARN: blocked-content guard fired for {url}: {blocked_reason}",
+                file=sys.stderr,
+            )
+
         # Layer 1: warn early when extraction is suspiciously thin.
         if len(text) < FETCH_QUALITY_MIN_CHARS:
             _emit_fetch_quality_warning(url, _LAST_FETCH_METRICS)
@@ -207,6 +263,11 @@ def fetch_url_content(url: str, timeout: int = 30) -> str:
                 # Only swap in the Playwright result if it actually improves things.
                 if pw_metrics.get('extracted_chars', 0) > len(text) and not pw_text.startswith('[ERROR'):
                     _LAST_FETCH_METRICS = pw_metrics
+                    # Re-run the blocked-content guard against the recovered
+                    # text (Issue #121): it may still be a blocked interstitial.
+                    pw_blocked, pw_reason = looks_blocked(pw_text)
+                    _LAST_FETCH_METRICS['blocked'] = pw_blocked
+                    _LAST_FETCH_METRICS['blocked_reason'] = pw_reason if pw_blocked else ''
                     print(
                         f"INFO: Playwright fetch recovered {pw_metrics['extracted_chars']} chars "
                         f"(BS4 had {len(text)})",
@@ -661,9 +722,42 @@ def main():
                 logging.error(f"Template processing error: {e}")
                 print(f"Template processing error: {e}", file=sys.stderr)
                 sys.exit(1)
-            
+
+            # Issue #121: if the fetch was blocked (anti-bot interstitial or
+            # un-hydrated SPA shell), skip the LLM call entirely and emit a
+            # blocked-stub instead. This is the load-bearing safety net that
+            # prevents hallucinated summaries from reaching workdesk/summaries/.
+            if _LAST_FETCH_METRICS.get('blocked'):
+                stub = build_blocked_stub(
+                    url=args.url,
+                    reason=_LAST_FETCH_METRICS.get('blocked_reason', 'unknown'),
+                    extracted_chars=_LAST_FETCH_METRICS.get('extracted_chars', 0),
+                    raw_bytes=_LAST_FETCH_METRICS.get('raw_bytes', 0),
+                    fetcher=_LAST_FETCH_METRICS.get('fetcher', 'unknown'),
+                )
+                print(
+                    f"BLOCKED: {args.url} — {_LAST_FETCH_METRICS.get('blocked_reason', '')}; "
+                    "writing blocked-stub instead of calling Gemini.",
+                    file=sys.stderr,
+                )
+                if args.output:
+                    try:
+                        with open(args.output, 'w', encoding='utf-8') as f:
+                            f.write(stub)
+                        logging.info(f"Wrote blocked-stub to {args.output}")
+                    except IOError as e:
+                        logging.error(f"Error writing blocked-stub to {args.output}: {e}")
+                        print(f"Error writing blocked-stub: {e}", file=sys.stderr)
+                        sys.exit(1)
+                else:
+                    print(stub)
+                # Exit 0: bulk_summarize.py treats this as a successful run
+                # and marks the source as checked. The BLOCKED: marker in
+                # the file body is what flags it for human review.
+                sys.exit(0)
+
             logging.info(f"Final prompt length: {len(prompt)} characters")
-            
+
             # args.clean = True  # Auto-enable cleaning for URL summarization
             args.model = 'gemini-3-flash-preview'  # Use latest model for URL summarization
             logging.info(f"Using model: {args.model} with clean output enabled")

--- a/scripts/modules/fetch_router.py
+++ b/scripts/modules/fetch_router.py
@@ -1,0 +1,197 @@
+"""Domain-aware fetch routing and anti-bot/SPA-shell guard.
+
+Issue #121: Some upstream domains either render content client-side (SPAs)
+or front the page with an anti-bot JavaScript challenge. The default curl +
+BeautifulSoup pipeline used by ``scripts/call-gemini.py`` then receives no
+real article text — and the LLM happily hallucinates a summary anyway.
+
+This module provides three small, pure functions so they can be tested in
+isolation and reused from any fetch path:
+
+- ``needs_spa_render(url)`` — should we route this URL through the headless
+  (Playwright) path instead of plain curl?
+- ``looks_blocked(extracted_text)`` — given the extracted text after
+  BeautifulSoup stripping, does it look like an anti-bot interstitial or an
+  un-hydrated SPA shell? If so, the LLM call MUST be skipped.
+- ``build_blocked_stub(url, reason, ...)`` — produce a clearly-flagged stub
+  payload (a short markdown document with a ``BLOCKED:`` marker) suitable
+  for writing to ``workdesk/summaries/`` so the URL is not silently retried
+  and so a human can spot it on sight during STEP_02 review.
+
+The router and guard are intentionally conservative:
+
+- ``needs_spa_render`` only returns ``True`` for hosts on a small explicit
+  allowlist. ``developers.openai.com`` is excluded — it is server-rendered
+  and routing it through Playwright would slow it down for no benefit.
+- ``looks_blocked`` triggers on either (a) extracted text below a length
+  threshold (currently 500 chars — the hallucination cases observed in the
+  issue extracted ~41 chars) or (b) literal interstitial signatures that
+  are well-documented (Cloudflare's "Just a moment...", OpenAI's
+  "Enable JavaScript and cookies to continue", etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+from urllib.parse import urlparse
+
+
+# Hosts whose pages are rendered client-side and therefore need a headless
+# browser. ``openai.com`` is included here because both ``/index/*`` and
+# ``/business/*`` sit behind a JS challenge; ``developers.openai.com`` is
+# explicitly excluded below because it is server-rendered.
+SPA_RENDER_HOSTS = (
+    "qwen.ai",
+    "chat.qwen.ai",
+    "openai.com",
+)
+
+# Suffix-match hosts (covers all subdomains of the suffix). E.g. any
+# ``*.notion.site`` page is an SPA.
+SPA_RENDER_HOST_SUFFIXES = (
+    ".notion.site",
+)
+
+# Hosts that LOOK like they would match the SPA allowlist but must NOT —
+# they are server-rendered and the curl path works fine.
+SPA_RENDER_EXCLUDED_HOSTS = (
+    "developers.openai.com",
+)
+
+# Below this many characters of extracted text we treat the fetch as
+# unreliable and refuse to summarise. The verified failure cases in
+# Issue #121 extracted ~41 chars; 500 is a comfortable safety margin
+# without tripping on legitimately short pages (a real article is
+# typically thousands of characters once script/style have been stripped).
+BLOCKED_MIN_CHARS = 500
+
+# Substrings that, when present in the extracted text, are a near-certain
+# indicator that we got an interstitial and not the article.
+INTERSTITIAL_SIGNATURES = (
+    # OpenAI's anti-bot gate (literal text confirmed in Issue #121).
+    "Enable JavaScript and cookies to continue",
+    # Cloudflare's challenge page common phrases.
+    "Just a moment...",
+    "Checking your browser",
+)
+
+
+def _hostname(url: str) -> str:
+    """Return the lower-cased hostname of ``url`` (``''`` if unparseable)."""
+    try:
+        host = urlparse(url).hostname or ""
+    except ValueError:
+        return ""
+    return host.lower()
+
+
+def needs_spa_render(url: str) -> bool:
+    """Return True if ``url`` should be fetched via a headless browser.
+
+    Routing rules (in order):
+
+    1. If the hostname is in :data:`SPA_RENDER_EXCLUDED_HOSTS`, return False
+       even if it would otherwise match — this is what protects
+       ``developers.openai.com`` from being routed through Playwright.
+    2. If the hostname matches an entry in :data:`SPA_RENDER_HOSTS`
+       (exact match or subdomain), return True.
+    3. If the hostname ends with one of :data:`SPA_RENDER_HOST_SUFFIXES`,
+       return True.
+    4. Otherwise, return False (use the plain curl path).
+    """
+    host = _hostname(url)
+    if not host:
+        return False
+
+    # Rule 1: explicit exclusions win.
+    for excluded in SPA_RENDER_EXCLUDED_HOSTS:
+        if host == excluded or host.endswith("." + excluded):
+            return False
+
+    # Rule 2: exact-or-subdomain match against the allowlist.
+    for allowed in SPA_RENDER_HOSTS:
+        if host == allowed or host.endswith("." + allowed):
+            return True
+
+    # Rule 3: suffix match (e.g. *.notion.site).
+    for suffix in SPA_RENDER_HOST_SUFFIXES:
+        if host.endswith(suffix):
+            return True
+
+    return False
+
+
+def looks_blocked(extracted_text: str) -> Tuple[bool, str]:
+    """Return ``(is_blocked, reason)`` for already-extracted page text.
+
+    "Extracted" here means: the result of BeautifulSoup stripping out
+    ``<script>``/``<style>`` tags and collapsing whitespace, i.e. exactly
+    what the LLM would otherwise be asked to summarise.
+
+    Two conditions trigger a block:
+
+    1. The extracted text contains a known interstitial signature
+       (Cloudflare challenge, OpenAI anti-bot gate, etc.). This wins over
+       the length check so the reason message is actionable.
+    2. The extracted text is shorter than :data:`BLOCKED_MIN_CHARS`. This
+       catches both un-hydrated SPA shells and unknown anti-bot pages.
+
+    The function never raises — a ``None`` or empty input is treated as
+    blocked with a descriptive reason.
+    """
+    if not extracted_text:
+        return True, "extracted text is empty (fetch produced no content)"
+
+    # Interstitial signatures first — they give a more useful reason.
+    for sig in INTERSTITIAL_SIGNATURES:
+        if sig in extracted_text:
+            return True, f"interstitial signature detected: {sig!r}"
+
+    n = len(extracted_text)
+    if n < BLOCKED_MIN_CHARS:
+        return (
+            True,
+            f"extracted text too short ({n} chars < {BLOCKED_MIN_CHARS} threshold); "
+            "page is likely an un-hydrated SPA shell or anti-bot challenge",
+        )
+
+    return False, ""
+
+
+def build_blocked_stub(
+    url: str,
+    reason: str,
+    extracted_chars: int,
+    raw_bytes: int,
+    fetcher: str,
+) -> str:
+    """Render a short markdown stub flagging ``url`` as un-summarisable.
+
+    The first line is intentionally a single ``BLOCKED:`` marker so a
+    human scrolling through ``workdesk/summaries/`` cannot miss it. The
+    body records the URL, the reason the guard fired, and the byte/char
+    counts observed during the fetch — enough context to decide whether
+    to (a) retry with a different fetcher, (b) curate the URL as
+    annex/omit, or (c) drop it.
+
+    This format is deliberately NOT the schema-valid summary JSON — the
+    summary validator would reject it, which is the correct behaviour:
+    blocked stubs must never be promoted into the published journal.
+    """
+    return (
+        "BLOCKED: summary suppressed — fetch did not return usable content.\n"
+        "\n"
+        f"- URL: {url}\n"
+        f"- Reason: {reason}\n"
+        f"- Fetcher: {fetcher}\n"
+        f"- Extracted chars: {extracted_chars}\n"
+        f"- Raw bytes: {raw_bytes}\n"
+        "\n"
+        "This stub was emitted by scripts/modules/fetch_router.py to prevent\n"
+        "the LLM from hallucinating a summary against an anti-bot interstitial\n"
+        "or an un-hydrated SPA shell. See Issue #121 for context.\n"
+        "\n"
+        "Action required: re-fetch this URL manually (e.g. via Playwright with\n"
+        "an authenticated session, or by archiving the page and feeding the\n"
+        "saved HTML), or curate the URL out of the journal.\n"
+    )

--- a/tests/fixtures/fetch/developers_openai_happy.html
+++ b/tests/fixtures/fetch/developers_openai_happy.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Codex memories chronicle - OpenAI Developers</title>
+<meta name="description" content="A walkthrough of how Codex agents persist memories across sessions, with worked examples and trade-offs.">
+<style>body{font-family:system-ui;max-width:760px;margin:auto;padding:2rem}</style>
+<script>window.__NEXT_DATA__={};</script>
+</head>
+<body>
+<header><nav><a href="/">Home</a> &middot; <a href="/codex">Codex</a></nav></header>
+<main>
+<article>
+<h1>Codex memories: a chronicle</h1>
+<p class="byline">Posted by the OpenAI Developers team. Last updated this week.</p>
+<p>This article walks through how Codex agents persist context across sessions, why the underlying memory store is structured the way it is, and what trade-offs we explored along the way. The goal is not to hand you a recipe; it is to make the engineering choices legible so you can adapt them to your own agent runtime.</p>
+<h2>Why a separate memory store at all?</h2>
+<p>The naive approach is to stuff every prior turn into the next prompt and let the model figure it out. That works for short tasks. For long-running coding agents it falls apart: token budgets blow up, latency degrades, and the model spends more attention on its own scratch notes than on the task at hand. We needed a memory store that could be queried selectively, evolved over time, and inspected by the developer.</p>
+<h2>What we tried first</h2>
+<p>Our first design was a flat append-only log keyed by session ID. Every tool call, every model output, every user message went in. Retrieval was a vector search over the log. This was easy to build but produced two recurring failure modes: the log accumulated junk faster than useful signal, and the vector index drifted as the codebase changed underneath the agent.</p>
+<h2>What we shipped</h2>
+<p>The shipped design splits memory into three tiers: a short-lived working set scoped to the current task, a per-repository knowledge layer that survives across sessions, and a global preferences layer that captures user-level conventions. Each tier has its own write path, its own retention policy, and its own retrieval surface. Crucially, the knowledge layer is pruned on a fixed schedule so it does not become a graveyard of stale findings.</p>
+<h2>Trade-offs</h2>
+<p>This design buys us inspectability and lets users delete memories that turned out to be misleading, at the cost of more moving parts. We think that is the right trade for a coding agent, where wrong memories are actively harmful — but it might not be the right trade for, say, a customer-support bot where breadth beats precision.</p>
+<h2>What is next</h2>
+<p>We are working on tooling to let developers diff memory state across sessions and roll back specific writes, which has come up repeatedly during dogfooding. Expect more on that soon.</p>
+</article>
+</main>
+<footer><p>&copy; OpenAI</p></footer>
+</body>
+</html>

--- a/tests/fixtures/fetch/notion_site_spa_shell.html
+++ b/tests/fixtures/fetch/notion_site_spa_shell.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Notion</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="icon" href="/favicon.ico">
+<script>window.CONFIG={publicPageId:"abc123"};</script>
+<script defer src="/_next/static/chunks/main.js"></script>
+<style>html,body{margin:0;height:100%}#__next{height:100%}</style>
+</head>
+<body>
+<div id="__next"></div>
+<noscript>This page requires JavaScript to be enabled.</noscript>
+</body>
+</html>

--- a/tests/fixtures/fetch/openai_index_antibot.html
+++ b/tests/fixtures/fetch/openai_index_antibot.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>OpenAI</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>html,body{height:100%;margin:0;background:#fff;color:#000;font-family:system-ui,sans-serif}#m{display:flex;height:100%;align-items:center;justify-content:center}</style>
+</head>
+<body>
+<div id="m"><noscript>Enable JavaScript and cookies to continue</noscript><p>Enable JavaScript and cookies to continue</p></div>
+<script>(function(){/* anti-bot challenge runtime */})();</script>
+</body>
+</html>

--- a/tests/fixtures/fetch/qwen_spa_shell.html
+++ b/tests/fixtures/fetch/qwen_spa_shell.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Qwen</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="icon" href="/favicon.ico">
+<script type="module" crossorigin src="/assets/index.js"></script>
+<style>body{margin:0;font-family:system-ui}</style>
+</head>
+<body>
+<div id="root"></div>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+</body>
+</html>

--- a/tests/test_fetch_router.py
+++ b/tests/test_fetch_router.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/modules/fetch_router.py` (Issue #121).
+
+Asserts that:
+
+1. ``needs_spa_render`` routes the SPA-render allowlist through the headless
+   path AND keeps the ``developers.openai.com`` happy path on the curl path.
+2. ``looks_blocked`` fires on each captured failure-mode fixture (SPA shell
+   from qwen.ai, SPA shell from *.notion.site, anti-bot interstitial from
+   openai.com/index/*) but does NOT fire on the happy-path fixture
+   (server-rendered developers.openai.com article).
+3. ``build_blocked_stub`` produces a body that humans cannot miss when
+   scrolling through ``workdesk/summaries/`` (must contain the literal
+   ``BLOCKED:`` marker, the URL, the reason, and the byte/char counts).
+
+Run from the repo root:
+
+    uv run python -m unittest tests.test_fetch_router
+    # or via pytest, if you have it:
+    uv run pytest tests/test_fetch_router.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+# Make ``scripts/`` importable without packaging.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from modules.fetch_router import (  # noqa: E402
+    BLOCKED_MIN_CHARS,
+    build_blocked_stub,
+    looks_blocked,
+    needs_spa_render,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "fetch"
+
+
+def _extract_text_like_call_gemini(html: str) -> str:
+    """Replicate the BeautifulSoup extraction that ``call-gemini.py`` does.
+
+    This is intentionally a local copy of the curl-path extraction logic in
+    ``scripts/call-gemini.py::fetch_url_content`` (strip script/style, get
+    text, collapse whitespace) so the test exercises exactly the same input
+    the LLM would otherwise see.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+    text = soup.get_text()
+    lines = (line.strip() for line in text.splitlines())
+    chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
+    return " ".join(chunk for chunk in chunks if chunk)
+
+
+class NeedsSpaRenderTest(unittest.TestCase):
+    """Router decides which URLs go through the SPA path."""
+
+    def test_qwen_routed_to_spa(self) -> None:
+        self.assertTrue(needs_spa_render("https://qwen.ai/some/page"))
+
+    def test_chat_qwen_routed_to_spa(self) -> None:
+        self.assertTrue(needs_spa_render("https://chat.qwen.ai/c/abc123"))
+
+    def test_notion_site_subdomain_routed_to_spa(self) -> None:
+        self.assertTrue(
+            needs_spa_render("https://example-team.notion.site/Some-Page-abc")
+        )
+
+    def test_openai_index_routed_to_spa(self) -> None:
+        self.assertTrue(needs_spa_render("https://openai.com/index/introducing-gpt-5-5/"))
+
+    def test_openai_business_routed_to_spa(self) -> None:
+        self.assertTrue(needs_spa_render("https://openai.com/business/workspace-agents/"))
+
+    def test_developers_openai_NOT_routed_to_spa(self) -> None:
+        # This is the load-bearing happy-path assertion: the curl path must
+        # not be replaced with Playwright for this host.
+        self.assertFalse(
+            needs_spa_render("https://developers.openai.com/codex/memories/chronicle")
+        )
+
+    def test_unrelated_domain_NOT_routed_to_spa(self) -> None:
+        self.assertFalse(needs_spa_render("https://example.com/article"))
+        self.assertFalse(needs_spa_render("https://qiita.com/user/items/abc"))
+
+    def test_invalid_url_does_not_crash(self) -> None:
+        # Defensive: malformed input must not raise.
+        self.assertFalse(needs_spa_render(""))
+        self.assertFalse(needs_spa_render("not-a-url"))
+
+
+class LooksBlockedFixtureTest(unittest.TestCase):
+    """Guard fires on captured failure-mode fixtures, not on the happy path."""
+
+    def _extracted(self, fixture_name: str) -> str:
+        path = FIXTURES / fixture_name
+        self.assertTrue(path.exists(), f"missing fixture: {path}")
+        return _extract_text_like_call_gemini(path.read_text(encoding="utf-8"))
+
+    def test_openai_index_antibot_is_blocked(self) -> None:
+        text = self._extracted("openai_index_antibot.html")
+        blocked, reason = looks_blocked(text)
+        self.assertTrue(blocked, msg=f"expected blocked, got reason={reason!r}, text={text!r}")
+        # Either the interstitial signature OR the length check must trip.
+        self.assertTrue(
+            "Enable JavaScript" in reason or "too short" in reason,
+            msg=f"unexpected reason: {reason!r}",
+        )
+
+    def test_qwen_spa_shell_is_blocked(self) -> None:
+        text = self._extracted("qwen_spa_shell.html")
+        blocked, reason = looks_blocked(text)
+        self.assertTrue(blocked, msg=f"expected blocked, got reason={reason!r}, text={text!r}")
+        self.assertIn("too short", reason)
+
+    def test_notion_spa_shell_is_blocked(self) -> None:
+        text = self._extracted("notion_site_spa_shell.html")
+        blocked, reason = looks_blocked(text)
+        self.assertTrue(blocked, msg=f"expected blocked, got reason={reason!r}, text={text!r}")
+        self.assertIn("too short", reason)
+
+    def test_developers_openai_happy_path_is_NOT_blocked(self) -> None:
+        text = self._extracted("developers_openai_happy.html")
+        # Sanity check: the happy-path fixture must actually have substantial
+        # extracted text — otherwise the test would pass for the wrong reason.
+        self.assertGreaterEqual(
+            len(text),
+            BLOCKED_MIN_CHARS,
+            msg=(
+                f"happy-path fixture extracted only {len(text)} chars; "
+                f"that is below the {BLOCKED_MIN_CHARS}-char threshold and "
+                "would falsely look blocked. The fixture itself is wrong."
+            ),
+        )
+        blocked, reason = looks_blocked(text)
+        self.assertFalse(
+            blocked,
+            msg=f"happy path should NOT be blocked but was: {reason!r}",
+        )
+
+
+class LooksBlockedSignatureTest(unittest.TestCase):
+    """Guard catches well-known interstitial signatures even on long-ish pages."""
+
+    def test_cloudflare_just_a_moment(self) -> None:
+        # Pad the rest of the body so it is over the length threshold —
+        # the signature alone must still trigger the block.
+        text = "Just a moment..." + (" filler" * 200)
+        blocked, reason = looks_blocked(text)
+        self.assertTrue(blocked)
+        self.assertIn("Just a moment", reason)
+
+    def test_cloudflare_checking_your_browser(self) -> None:
+        text = "Checking your browser before accessing site" + (" filler" * 200)
+        blocked, reason = looks_blocked(text)
+        self.assertTrue(blocked)
+        self.assertIn("Checking your browser", reason)
+
+    def test_empty_text_is_blocked(self) -> None:
+        blocked, reason = looks_blocked("")
+        self.assertTrue(blocked)
+        self.assertIn("empty", reason)
+
+
+class BuildBlockedStubTest(unittest.TestCase):
+    """Stub body must be obvious-on-sight in workdesk/summaries/."""
+
+    def test_stub_has_BLOCKED_marker_first(self) -> None:
+        stub = build_blocked_stub(
+            url="https://openai.com/index/foo",
+            reason="interstitial signature detected",
+            extracted_chars=41,
+            raw_bytes=9949,
+            fetcher="curl+bs4",
+        )
+        first_line = stub.splitlines()[0]
+        self.assertTrue(
+            first_line.startswith("BLOCKED:"),
+            msg=f"expected BLOCKED: marker on first line, got {first_line!r}",
+        )
+
+    def test_stub_records_url_reason_and_counts(self) -> None:
+        stub = build_blocked_stub(
+            url="https://qwen.ai/article",
+            reason="extracted text too short (12 chars)",
+            extracted_chars=12,
+            raw_bytes=4567,
+            fetcher="curl+bs4",
+        )
+        self.assertIn("https://qwen.ai/article", stub)
+        self.assertIn("extracted text too short", stub)
+        self.assertIn("12", stub)
+        self.assertIn("4567", stub)
+        self.assertIn("curl+bs4", stub)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #121

## Summary

The summarization pipeline was silently producing hallucinated summaries for any URL where curl + BeautifulSoup could not get real article text. Issue #121 documents two distinct failure modes — SPA hydration (`qwen.ai`, `chat.qwen.ai`, `*.notion.site`) and anti-bot JS challenges (`openai.com/index/*`, `openai.com/business/*` returning a 41-char "Enable JavaScript and cookies to continue" interstitial). `developers.openai.com` is server-rendered and unaffected; it must NOT be routed through the SPA path.

This PR adds three small, surgical pieces:

1. **`scripts/modules/fetch_router.py`** — new module, three pure functions:
   - `needs_spa_render(url)`: returns `True` for the SPA allowlist (`qwen.ai`, `chat.qwen.ai`, `openai.com`, `*.notion.site`) with `developers.openai.com` explicitly excluded.
   - `looks_blocked(text)`: returns `(is_blocked, reason)`. Triggers on (a) text shorter than 500 chars or (b) known interstitial signatures (`Enable JavaScript and cookies to continue`, `Just a moment...`, `Checking your browser`).
   - `build_blocked_stub(...)`: renders a markdown body whose first line is a literal `BLOCKED:` marker, with the URL, the reason, and the byte/char counts.
2. **`scripts/call-gemini.py`** integrates both:
   - SPA hosts are routed through Playwright first (gated on it being importable — see Playwright dep note below).
   - The guard runs after extraction regardless of fetch path.
   - When the guard fires, the LLM call is skipped entirely and the blocked stub is written at the same `--output` path that successful summaries use, so `bulk_summarize.py`'s `output_path.exists()` check still treats the URL as processed.
3. **Regression fixtures + test**:
   - `tests/fixtures/fetch/openai_index_antibot.html` (interstitial)
   - `tests/fixtures/fetch/qwen_spa_shell.html` (un-hydrated SPA)
   - `tests/fixtures/fetch/notion_site_spa_shell.html` (un-hydrated SPA)
   - `tests/fixtures/fetch/developers_openai_happy.html` (server-rendered, ~2000 chars of real prose)
   - `tests/test_fetch_router.py` (17 tests, all passing)

## Test plan

- [x] `uv run python -m unittest tests.test_fetch_router` — 17 new tests pass; covers router decisions for every host class in the issue, guard fires on each captured failure-mode fixture, guard does NOT fire on the happy-path fixture, and the stub body has the `BLOCKED:` marker plus URL/reason/counts.
- [x] `uv run python -m unittest tests.test_validate_summary` — existing 23 tests still pass (no regression).
- [x] `uv run scripts/bulk_summarize.py --dry-run` — completes without error.
- [x] `uv run python scripts/call-gemini.py --help` — argparse still parses cleanly.

## Audit note (action for maintainer)

Past summaries on these domains were generated against the wrong content (interstitial or SPA shell) and should be re-generated:

- [ ] `openai.com/index/*` summaries
- [ ] `openai.com/business/*` summaries
- [ ] `qwen.ai` and `chat.qwen.ai` summaries
- [ ] `*.notion.site` summaries

After this PR is merged, re-running the summarizer for those URLs will either produce a real summary (Playwright-rendered) or a clearly-flagged `BLOCKED:` stub. `developers.openai.com` summaries are unaffected and do not need re-generation.

## Playwright dep note

Playwright is already declared in `pyproject.toml` (`playwright>=1.58.0`), so I used it directly. The SPA path still gates on `import playwright` succeeding so the script does not hard-crash if a future environment removes it; in that case, the SPA hosts fall through to the curl path and the blocked-content guard fires, writing a stub instead of hallucinating. That is a strict improvement over the pre-PR behaviour either way.

I did NOT change `pyproject.toml` in this PR. If running headless Chromium also requires `uv run playwright install chromium`, the maintainer should run that separately on the summarization host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)