### PR TITLE
fix(add-url): preserve input order when bulk adding URLs

### DIFF
--- a/.claude/skills/add-url/SKILL.md
+++ b/.claude/skills/add-url/SKILL.md
@@ -74,6 +74,42 @@ When given multiple URLs:
    - Duplicates skipped
    - Any errors
 
+### Ordering Guarantee (Input Order Preservation)
+
+When the user supplies an ordered list of URLs, the IDs assigned in
+`workdesk/sources.md` MUST reflect that input order. This is a hard contract,
+not a best-effort behavior — downstream STEP_02 verification cross-checks
+summaries against the original input list by ID.
+
+**Rules:**
+
+1. **Strict input order.** URLs are validated and appended to `sources.md`
+   strictly sequentially in the order received. Do NOT validate or append
+   multiple URLs in parallel (no parallel `Bash` tool calls for `check_link.py`
+   across different URLs in the same batch, no parallel `Edit` calls to
+   `sources.md`). Finish one URL fully — validate, then append (or skip) — before
+   touching the next.
+2. **Duplicates and failures do not consume IDs.** If a URL is a duplicate
+   (`check_link.py` reports it already exists) or fails validation, skip it and
+   move to the next URL. The next ID is reserved only when an entry is actually
+   committed to `sources.md`.
+3. **Assigned IDs strictly increase in input order.** Given input
+   `[URL_A, URL_B, URL_C]` where `URL_B` is a duplicate, the result is:
+   - `URL_A` → lowest new ID (e.g. `213`)
+   - `URL_B` → skipped (no ID consumed)
+   - `URL_C` → next ID (`214`)
+
+   `URL_C` MUST NOT receive an ID lower than `URL_A`'s.
+
+**Why it matters:** STEP_02 (summarization) and any manual spot-check against
+the user's original URL list rely on `ID order == input order`. Any
+out-of-order assignment forces manual re-alignment downstream and is treated as
+a bug (see issue #120).
+
+The `scripts/bulk_add_links.py` helper, when used, encodes this same contract:
+URLs are processed one at a time and the next ID is only assigned after the
+previous URL has been committed to `sources.md`.
+
 ## What This Skill Does NOT Do
 
 - ❌ Does NOT generate summaries

--- a/scripts/bulk_add_links.py
+++ b/scripts/bulk_add_links.py
@@ -234,12 +234,20 @@ def main():
         print("No URLs found.")
         sys.exit(0)
 
-    # Process URLs
+    # Process URLs strictly sequentially in input order.
+    #
+    # Ordering guarantee (see issue #120):
+    # - URLs are validated and appended to sources.md one at a time, in the
+    #   exact order received from the input.
+    # - Duplicates and validation failures are skipped WITHOUT consuming an ID.
+    # - The next ID is only assigned and incremented after the previous URL has
+    #   been committed to sources.md, so assigned IDs strictly increase in
+    #   input order.
     results: Dict[str, dict] = {}
     next_id = get_next_id(sources_file)
 
     print("=" * 60)
-    print("PHASE 1: Validating URLs")
+    print("Processing URLs (sequential, input order preserved)")
     print("=" * 60)
 
     for url in urls:
@@ -249,24 +257,60 @@ def main():
         if args.verbose:
             print(message)
 
-        if is_unique:
-            results[url] = {
-                'unique': True,
-                'sanitized': sanitized_url,
-                'id': next_id,
-                'added': False,
-                'summarized': False,
-                'marked': False
-            }
-            print(f"✓ UNIQUE - Will add as ID {next_id:03d}")
-            next_id += 1
-        else:
+        if not is_unique:
             results[url] = {
                 'unique': False,
                 'sanitized': sanitized_url,
                 'message': message
             }
-            print(f"✗ DUPLICATE or ERROR")
+            print(f"✗ DUPLICATE or ERROR (skipped, no ID consumed)")
+            continue
+
+        # URL is unique. Reserve the next ID and append immediately so that
+        # subsequent URLs see this entry when computing duplicates / next ID.
+        assigned_id = next_id
+        data = {
+            'unique': True,
+            'sanitized': sanitized_url,
+            'id': assigned_id,
+            'added': False,
+            'summarized': False,
+            'marked': False,
+        }
+        results[url] = data
+        print(f"✓ UNIQUE - Assigning ID {assigned_id:03d}")
+
+        if args.dry_run:
+            # In dry-run we still increment so the printed sequence reflects
+            # the IDs that WOULD be assigned, in input order.
+            next_id += 1
+            continue
+
+        if add_url_to_sources(sources_file, sanitized_url, assigned_id):
+            data['added'] = True
+            next_id += 1
+            print(f"✓ Added to sources.md as {assigned_id:03d}")
+        else:
+            print(f"✗ Failed to add to sources.md (ID {assigned_id:03d} not consumed)")
+            # Do NOT increment next_id: the append failed, so the ID is free
+            # for the next URL. This preserves the contiguous ordering
+            # guarantee for IDs that actually land in sources.md.
+            continue
+
+        # Generate summary inline (still sequential per URL) unless suppressed.
+        if not args.no_summarize:
+            print(f"[{assigned_id:03d}] Generating summary: {sanitized_url}")
+            success, result = generate_summary(sanitized_url, assigned_id, summaries_dir)
+
+            if success:
+                data['summarized'] = True
+                print(f"✓ Summary saved: {result}")
+
+                if mark_as_processed(sources_file, assigned_id):
+                    data['marked'] = True
+                    print(f"✓ Marked as processed")
+            else:
+                print(f"✗ Failed: {result}")
 
     # Count unique URLs
     unique_urls = [url for url, data in results.items() if data.get('unique', False)]
@@ -275,50 +319,6 @@ def main():
     if args.dry_run:
         print("\nDRY RUN - No changes made")
         sys.exit(0)
-
-    if not unique_urls:
-        print("\nNo URLs to add.")
-        sys.exit(0)
-
-    # Add URLs to sources.md
-    print("\n" + "=" * 60)
-    print("PHASE 2: Adding to sources.md")
-    print("=" * 60)
-
-    for url in unique_urls:
-        data = results[url]
-        print(f"\n[{data['id']:03d}] Adding: {data['sanitized']}")
-
-        if add_url_to_sources(sources_file, data['sanitized'], data['id']):
-            data['added'] = True
-            print(f"✓ Added to sources.md")
-        else:
-            print(f"✗ Failed to add")
-
-    # Generate summaries
-    if not args.no_summarize:
-        print("\n" + "=" * 60)
-        print("PHASE 3: Generating summaries")
-        print("=" * 60)
-
-        for url in unique_urls:
-            data = results[url]
-            if not data['added']:
-                continue
-
-            print(f"\n[{data['id']:03d}] Generating summary: {data['sanitized']}")
-            success, result = generate_summary(data['sanitized'], data['id'], summaries_dir)
-
-            if success:
-                data['summarized'] = True
-                print(f"✓ Summary saved: {result}")
-
-                # Mark as processed
-                if mark_as_processed(sources_file, data['id']):
-                    data['marked'] = True
-                    print(f"✓ Marked as processed")
-            else:
-                print(f"✗ Failed: {result}")
 
     # Final summary
     print("\n" + "=" * 60)


### PR DESCRIPTION
Closes #120.

## Summary

- Restructure `scripts/bulk_add_links.py` from a two-phase (validate-all, then write-all) flow into a single sequential per-URL loop: validate, then append to `workdesk/sources.md`, then move to the next URL. The next ID is assigned only after the previous URL has been committed, so assigned IDs strictly increase in input order. Duplicates, validation failures, and append failures skip without consuming an ID.
- Document the ordering contract explicitly under "Batch Processing Strategy" in `.claude/skills/add-url/SKILL.md` so the agent invokes the workflow strictly sequentially (no parallel `check_link.py` Bash calls or parallel `Edit`s to `sources.md` across URLs in the same batch). Downstream STEP_02 verification can now rely on `ID order == input order`.

## Test plan

- [x] `uv run scripts/bulk_add_links.py --help` still prints the same CLI surface (`--dry-run`, `--no-summarize`, `--verbose`).
- [x] Synthetic test (mocked `check_url` / `add_url_to_sources` / `get_next_id`):
  - Input `[A, B(dup), C, D]` starting at next ID 213 produces writes `[(A, 213), (C, 214), (D, 215)]` — duplicates do not consume IDs and IDs strictly increase in input order.
  - Input `[A, B, C]` where the append for `B` fails produces writes `[(A, 213), (C, 214)]` — failed appends do not consume IDs either.
- [x] Dry-run with three test URLs prints IDs in input order and does not mutate `workdesk/sources.md`.
- [ ] Manual end-to-end run on a real batch when next adding URLs to `workdesk/sources.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)