### PR TITLE
Add human-review-gate skill for blocking planning-doc reviews

### DIFF
--- a/.claude/skills/human-review-gate/SKILL.md
+++ b/.claude/skills/human-review-gate/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: human-review-gate
+description: Blocking human review gate for AI-drafted planning documents. Opens the file in a tmux popup with vim, blocks until the editor closes, and verifies a human-authored approval marker. Use at every "AI drafts → human reviews → AI proceeds" handoff (STEP_03b editorial plan, STEP_07 assembly strategy, etc.).
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# Human Review Gate
+
+Many workflow steps require a human to review an AI-drafted planning document before
+the workflow can continue. This skill is the **single mechanism** for that gate. Use
+it at every such handoff.
+
+## When to Use This Skill
+
+Use this skill whenever:
+
+- A workflow step requires human review of an AI-drafted document before
+  proceeding (e.g. STEP_03b approves `editorial_plan_YYYY_MM_DD.md`, STEP_07
+  approves the assembly strategy section appended to the same plan).
+- The agent has just regenerated or substantially edited a planning document
+  that was already approved — re-review is required.
+- Any future step adds a human-in-the-loop checkpoint over a markdown artifact.
+
+Do **not** use this skill for:
+
+- Quick yes/no confirmations (use `AskUserQuestion` directly).
+- Reviewing diffs or PRs (use `gh pr review`).
+- Soliciting feedback on a draft that has not yet been written to a file.
+
+## Contract
+
+A review gate has succeeded if and only if **both** are true after the call:
+
+1. The file has been opened in vim by the human, and they have closed the editor.
+2. The file contains a human-authored approval marker matching the agreed pattern.
+
+The agent **MUST NOT** write the approval marker on the human's behalf. The human
+authors the marker inside vim. Writing the approval line for the human defeats
+the entire purpose of this gate.
+
+## Default Approval Markers
+
+Planning documents in this repo use checked-checkbox approval lines:
+
+```
+- [x] APPROVED - Ready for STEP_04 curation             (STEP_03b)
+- [x] ASSEMBLY PLAN APPROVED - Ready for STEP_08         (STEP_07)
+```
+
+The agent writes the line as `- [ ]` (unchecked). The human flips it to `- [x]`
+inside vim during review. The grep pattern matches the checked form only.
+
+## Workflow
+
+### 1. Pre-Flight
+
+Before invoking the gate:
+
+- [ ] The planning document is fully drafted and saved to disk.
+- [ ] An unchecked approval line is present in the file as the canonical
+  marker, e.g. `- [ ] APPROVED - Ready for STEP_04 curation`.
+- [ ] Working directory is the repo root.
+
+### 2. Invoke the Gate
+
+```bash
+bash scripts/review_in_popup.sh \
+  workdesk/editorial_plan_YYYY_MM_DD.md \
+  '^- \[x\] APPROVED'
+```
+
+Replace the file path and pattern for the calling step. The script:
+
+1. Opens the file in `vim` inside a blocking `tmux display-popup -E` popup.
+2. Blocks until the human closes vim.
+3. Re-reads the file from disk and `grep -E`-matches the approval pattern.
+4. Returns exit code:
+   - `0` → approval marker found, proceed.
+   - `1` → marker not found, **do not proceed**.
+   - `2` → not in a tmux session, fall back (see §4).
+   - `3` → usage error in the skill invocation, fix the call.
+
+### 3. Handle Results
+
+**Exit 0 (approved):**
+
+- Confirm to the user with one short sentence (e.g. "Editorial plan approved, proceeding to STEP_04.").
+- Continue the workflow.
+
+**Exit 1 (not approved):**
+
+- Do **not** continue past the gate.
+- Read the file to surface any inline comments or edits the human left.
+- Use `AskUserQuestion` to ask what revisions are needed, or summarize the
+  edits you noticed and propose next steps.
+- After making revisions, **re-invoke this skill**.
+
+**Exit 1 with no edits visible:**
+
+- The human may have closed the popup without acting. Ask whether they want
+  to retry the review or take a different path.
+
+### 4. Fallback: No tmux Session (Exit 2)
+
+If `scripts/review_in_popup.sh` exits with `2`, the user is not running Claude
+Code inside tmux. The skill cannot pop a blocking editor. Fall back to:
+
+1. Tell the user explicitly:
+
+   > "I can't open a tmux popup (no tmux session detected). Please review the
+   > file at `<path>` in your editor and add the line `- [x] APPROVED ...`
+   > yourself when ready."
+
+2. Use `AskUserQuestion` with options:
+   - "I've reviewed and approved the file"
+   - "Needs revision — I'll describe changes"
+
+3. Only after the user selects "approved", re-run the grep check yourself:
+
+   ```bash
+   grep -qE '^- \[x\] APPROVED' workdesk/editorial_plan_YYYY_MM_DD.md
+   ```
+
+   If still not present, ask the user to add it. Do **not** write it for them.
+
+### 5. Re-Review After Agent Edits
+
+If the agent modifies the planning document after a successful gate (e.g.
+STEP_07 appends Assembly Strategies to the same file approved in STEP_03b),
+the prior approval **does not cover the new content**. Re-invoke this skill
+with the new section's approval marker before proceeding.
+
+Practical rule: every time the agent wants to advance past a documented review
+gate, the most recent action on the planning file must be an editor-close
+captured by this skill.
+
+## What This Skill Does NOT Do
+
+- ❌ Does NOT write the approval marker for the human.
+- ❌ Does NOT auto-approve based on diff inspection or "the file looks done".
+- ❌ Does NOT batch multiple review gates into one popup — one file per call.
+- ❌ Does NOT silently retry on failure; on exit 1, surface the failure to
+  the user and discuss before retrying.
+
+## Why a tmux Popup
+
+The popup gives:
+
+- **Synchronous blocking.** The agent's `Bash` call only returns when vim exits.
+  No way to "forget" the gate.
+- **Full-file context.** The human sees the entire document, not chat snippets.
+- **In-place editing.** Edits land in the same file the next step consumes.
+- **Auditability.** The file's `mtime` and any subsequent `git diff` make it
+  obvious that a human touched the document.
+
+## Examples
+
+**STEP_03b approval:**
+
+```bash
+bash scripts/review_in_popup.sh \
+  workdesk/editorial_plan_2026_05_23.md \
+  '^- \[x\] APPROVED - Ready for STEP_04 curation'
+```
+
+**STEP_07 assembly strategy approval (re-review of same file):**
+
+```bash
+bash scripts/review_in_popup.sh \
+  workdesk/editorial_plan_2026_05_23.md \
+  '^- \[x\] ASSEMBLY PLAN APPROVED - Ready for STEP_08'
+```
+
+## Relationship to Other Skills
+
+- **Before** this skill: AI drafts the planning document with an unchecked
+  approval line as the last status item.
+- **After** this skill (exit 0): the calling step proceeds (curation, assembly, etc.).
+- **After** this skill (exit 1): AI iterates on the draft and re-invokes.
+
+You are strict about the gate's contract. You never write the approval marker
+yourself, and you never proceed past a gate without a successful exit 0 from
+this skill (or an explicit chat-based fallback when tmux is unavailable).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,21 @@ This repository creates weekly curated journals about Generative AI in coding, f
   - Uses `uv run scripts/bulk_summarize.py` for batch operations
   - Marks URLs as checked after successful summary generation
 
+- **human-review-gate skill**: Blocking review of AI-drafted planning documents
+  - Invoked at every "AI drafts → human reviews → AI proceeds" handoff
+    (currently STEP_03b editorial plan approval and STEP_07 assembly strategy
+    approval; any future planning gate must use this skill)
+  - Opens the file in a tmux popup running vim via
+    `scripts/review_in_popup.sh`, blocks until the human closes vim, then
+    verifies a checked approval line (`- [x] APPROVED ...`) exists
+  - **Hard rule: the agent must NOT write the `[x]` itself** — the human
+    authors the approval marker inside vim. The agent writes the line as
+    `- [ ]` only; flipping it is the human's signal.
+  - Falls back to chat-based `AskUserQuestion` confirmation (still file-based
+    grep-checked) when not running inside a tmux session
+  - If the agent edits a planning document after a successful gate, the prior
+    approval does not cover the new content — re-invoke the skill
+
 ## Frequently Used Commands
 ```bash
 # Create journal directory structure

--- a/STEP_03b_PLAN_THEMES.md
+++ b/STEP_03b_PLAN_THEMES.md
@@ -193,19 +193,35 @@ For each theme:
 
 **⚠️ WORKFLOW STOPS HERE - HUMAN APPROVAL REQUIRED ⚠️**
 
-#### 8. Review and Refine Editorial Plan
+This gate is enforced by the **`human-review-gate` skill**
+(`.claude/skills/human-review-gate/SKILL.md`). The agent invokes the skill;
+the skill opens the planning document in a tmux popup running vim, blocks
+until the human closes the editor, and verifies that a checked approval line
+is present. The agent **must not** check the approval line itself — the human
+authors it inside vim.
 
-**Human Editor Tasks:**
+#### 8. Review and Refine Editorial Plan (in vim popup)
 
-- [ ] Review proposed themes for coherence
-- [ ] Verify article-to-theme mappings make editorial sense
-- [ ] Refine theme titles for clarity and specificity
-- [ ] Edit theme introductions to be factual and concise
-- [ ] Adjust highlight outline to capture week's essence
-- [ ] Reassign articles between themes as needed
-- [ ] Decide which articles belong in main vs. annex
+**Agent invokes the gate:**
 
-**Quality Checks:**
+```bash
+bash scripts/review_in_popup.sh \
+  workdesk/editorial_plan_YYYY_MM_DD.md \
+  '^- \[x\] APPROVED - Ready for STEP_04 curation'
+```
+
+The popup opens vim on the planning document. While inside the popup, the
+**human editor**:
+
+- [ ] Reviews proposed themes for coherence
+- [ ] Verifies article-to-theme mappings make editorial sense
+- [ ] Refines theme titles for clarity and specificity
+- [ ] Edits theme introductions to be factual and concise
+- [ ] Adjusts highlight outline to capture the week's essence
+- [ ] Reassigns articles between themes as needed
+- [ ] Decides which articles belong in main vs. annex
+
+**Quality Checks (human runs through this list inside vim):**
 
 - [ ] Are themes well-grouped by topic?
 - [ ] Does the plan present articles factually without manufactured narratives?
@@ -217,12 +233,20 @@ For each theme:
 - [ ] If any theme has fewer than 3 articles, is there documented justification? (Single-article themes are permitted for truly exceptional content — see STEP_04 Section 4 for criteria.)
 - [ ] Do themes align with curation_criteria.md principles?
 
-#### 9. Mark Plan as Approved
+When satisfied, the human flips the unchecked approval line under "Planning
+Status" from `- [ ] APPROVED ...` to `- [x] APPROVED ...` and writes/quits.
+The skill verifies the marker and returns:
 
-- [ ] Update "Planning Status" section in editorial_plan_YYYY_MM_DD.md
-- [ ] Check ✅ "APPROVED - Ready for STEP_04 curation"
-- [ ] Add review notes documenting any changes
-- [ ] Commit planning document to git
+- Exit `0` → approval found, proceed to step 9.
+- Exit `1` → no approval marker; agent reads the file for inline edits/comments,
+  asks the human what revisions are needed, applies them, then **re-invokes
+  the gate**.
+- Exit `2` → no tmux session detected; agent falls back to chat-based
+  approval per the skill's §4 (file-based check still required).
+
+#### 9. Commit Approved Plan
+
+After the gate returns exit `0`, commit:
 
 ```bash
 git add workdesk/editorial_plan_YYYY_MM_DD.md

--- a/STEP_07_ASSEMBLY_PLANNING.md
+++ b/STEP_07_ASSEMBLY_PLANNING.md
@@ -222,9 +222,27 @@ For each theme, add to editorial plan:
   - AI and human customize (Phase 2 Step 3)
   - AI documents assembly strategy
 
-- [ ] Human reviews complete assembly plan
+- [ ] Once all themes have a documented assembly strategy, **invoke the
+  `human-review-gate` skill** to gate progression to STEP_08:
 
-- [ ] Human approves: ✅ ASSEMBLY STRATEGIES APPROVED
+  ```bash
+  bash scripts/review_in_popup.sh \
+    workdesk/editorial_plan_YYYY_MM_DD.md \
+    '^- \[x\] ASSEMBLY PLAN APPROVED - Ready for STEP_08'
+  ```
+
+  This is a **re-review** of the same file approved at STEP_03b — the
+  STEP_03b approval does not cover the new ASSEMBLY STRATEGIES section.
+  The skill opens the file in a tmux popup running vim, blocks until the
+  editor closes, and verifies the human flipped
+  `- [ ] ASSEMBLY PLAN APPROVED - Ready for STEP_08` to `- [x] ...`.
+
+  - Exit `0` → proceed to STEP_08.
+  - Exit `1` → revise the assembly strategies based on the human's edits
+    and re-invoke.
+  - Exit `2` → fall back to the skill's chat-based confirmation (§4).
+
+  See `.claude/skills/human-review-gate/SKILL.md` for the full contract.
 
 ---
 
@@ -293,7 +311,11 @@ For each theme, add to editorial plan:
 - [x] Phase 1: Pattern library reviewed
 - [x] Phase 2: Patterns selected and customized for all themes
 - [x] Phase 3: Assembly strategies documented
-- [x] ASSEMBLY PLAN APPROVED - Ready for STEP_08
+- [ ] ASSEMBLY PLAN APPROVED - Ready for STEP_08
+
+> The agent leaves `ASSEMBLY PLAN APPROVED` **unchecked** when generating the
+> document. The human flips it to `[x]` inside the `human-review-gate` vim
+> popup; the agent must not check it.
 
 **Approval Date:** [YYYY-MM-DD]
 **Approver:** [Human Editor Name]

--- a/scripts/review_in_popup.sh
+++ b/scripts/review_in_popup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Open a planning document for synchronous human review in a tmux popup,
+# block until the editor closes, then verify an approval marker exists.
+#
+# Usage: review_in_popup.sh <file> <approval_pattern>
+#   <file>             path to the file to review
+#   <approval_pattern> grep -E pattern that the human must add for approval
+#
+# Exit codes:
+#   0  approval pattern found (proceed past gate)
+#   1  approval pattern not found (do not proceed)
+#   2  not running inside tmux — caller must fall back to chat-based approval
+#   3  usage error
+
+set -euo pipefail
+
+FILE="${1:-}"
+PATTERN="${2:-}"
+
+if [[ -z "$FILE" || -z "$PATTERN" ]]; then
+  echo "usage: $0 <file> <approval_pattern>" >&2
+  exit 3
+fi
+
+if [[ ! -f "$FILE" ]]; then
+  echo "ERROR: file not found: $FILE" >&2
+  exit 3
+fi
+
+if [[ -z "${TMUX:-}" ]]; then
+  echo "ERROR: not running inside a tmux session." >&2
+  echo "human-review-gate requires tmux for blocking review." >&2
+  echo "Caller should fall back to chat-based approval." >&2
+  exit 2
+fi
+
+# Open file in vim inside a blocking tmux popup.
+#   -E              : close popup when command exits, propagate exit status.
+#   -w 90% -h 90%   : nearly full-screen so reviewer sees the whole document.
+#   +set ft=markdown: force markdown filetype regardless of detection.
+#   +normal! gg     : jump to top of file on open.
+tmux display-popup -E -w 90% -h 90% \
+  "vim '+set ft=markdown' '+normal! gg' '$FILE'"
+
+# After the popup closes, re-read the file and look for the approval marker.
+if grep -qE "$PATTERN" "$FILE"; then
+  echo "✓ approval marker matched: /$PATTERN/"
+  exit 0
+fi
+
+echo "✗ approval marker not found in $FILE." >&2
+echo "Pattern: /$PATTERN/" >&2
+exit 1


### PR DESCRIPTION
## Summary

Closes #130.

Codifies a single mechanism for the "AI drafts → human reviews → AI proceeds" handoffs at **STEP_03b** (editorial plan) and **STEP_07** (assembly strategy). The agent invokes `scripts/review_in_popup.sh`, which opens the planning document in a `tmux display-popup -E` running `vim`, blocks until the editor closes, then `grep -E`-checks the file for a human-authored approval line.

**The hard rule:** the agent must never write the `[x]` itself. The agent writes `- [ ] APPROVED ...`; the human flips it to `- [x] APPROVED ...` inside vim. That flip is the gate's signal.

## What's in the PR

- `scripts/review_in_popup.sh` — tmux-popup wrapper around vim with explicit exit codes:
  - `0` approved (proceed)
  - `1` no approval marker (do not proceed; iterate, re-invoke)
  - `2` no tmux session (caller falls back to chat-based confirmation)
  - `3` usage error
- `.claude/skills/human-review-gate/SKILL.md` — when to use, contract, fallback path, re-review-after-agent-edits rule, examples.
- `STEP_03b_PLAN_THEMES.md` — Part B invokes the skill with `^- \[x\] APPROVED - Ready for STEP_04 curation`.
- `STEP_07_ASSEMBLY_PLANNING.md` — Phase 3 invokes the skill for **re-review** of the same plan file with `^- \[x\] ASSEMBLY PLAN APPROVED - Ready for STEP_08`; template's pre-checked approval line corrected to unchecked so the agent doesn't accidentally pre-approve.
- `CLAUDE.md` — skill listed alongside `add-url` / `summarize-source`, including the "agent must NOT write the `[x]`" rule.

## Decisions (matching the issue's open questions)

| Question | Choice |
|---|---|
| Skill vs. hook vs. doc | **Skill** (`human-review-gate`), referenced from STEP files. Composable, explicit invocation point. No hook for now. |
| Outside-tmux fallback | Exit `2` → caller does chat-based `AskUserQuestion`, still file-grep-verified. The agent never writes the marker even in fallback. |
| Approval signal | **File-based**: `- [ ]` → `- [x]` flip on a canonical approval line. `:wq` vs. `:cq` was rejected because users hit `:wq` reflexively. |
| Re-review on agent edits | Documented as a hard rule. STEP_07 is the canonical case (same file gets new content after STEP_03b approval). |
| Scope | STEP_03b + STEP_07 only for now. CLAUDE.md states future planning gates must use the same skill. |

## Test plan

- [x] `scripts/review_in_popup.sh` (no args) → exit 3, prints usage
- [x] `scripts/review_in_popup.sh /tmp/missing 'pat'` → exit 3, "file not found"
- [x] `env -u TMUX bash scripts/review_in_popup.sh <real-file> 'pat'` → exit 2, "not running inside a tmux session"
- [ ] Inside tmux: drive end-to-end on the next journal week's STEP_03b → `editorial_plan_2026_05_23.md`. Expected: popup opens, vim shows the file, closing without flipping the checkbox returns exit 1; flipping `- [ ]` to `- [x]` and `:wq` returns exit 0.
- [ ] STEP_07 re-review of the same file with the assembly-plan pattern works as a second invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)