### PR TITLE
Harden mark_published.py + Supabase remediation tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,10 @@ uv run scripts/sanitize_url.py "URL_HERE"
 
 # STEP_10: Mark Supabase summaries as published (REQUIRED — see STEP_10 Section 6)
 # Run AFTER archiving to journals/YYYY-MM-DD/ and BEFORE creating the PR (STEP_12).
-# Sets journal_date for ALL workdesk-state Supabase summaries (NULL journal_date),
-# transitioning them to published. Skipping breaks /journals/YYYY-MM-DD/NNN/ pages.
+# Scoped: sets journal_date ONLY for THIS journal's summaries (matched by URL
+# against journals/YYYY-MM-DD/summaries/), transitioning them to published.
+# Skipping breaks /journals/YYYY-MM-DD/NNN/ pages. (--all-null forces the old
+# blanket behavior; avoid it — it sweeps unrelated NULL rows into this date.)
 uv run scripts/mark_published.py YYYY-MM-DD
 ```
 

--- a/STEP_10_CLEANUP.md
+++ b/STEP_10_CLEANUP.md
@@ -291,12 +291,18 @@ uv run scripts/mark_published.py YYYY-MM-DD
 ```
 
 **What this does:**
-- Updates `journal_date` field in Supabase for all workdesk summaries (journal_date IS NULL)
-- Transitions summaries from draft (workdesk) to published state
+- Updates `journal_date` in Supabase ONLY for **this journal's** summaries, matched by
+  URL against `journals/YYYY-MM-DD/summaries/*.json` (with a `workdesk/summaries/` fallback)
+- Transitions those summaries from draft (workdesk) to published state
 - Enables public read access via Row Level Security (RLS) policy
 - Preserves summary URLs: `/journals/YYYY-MM-DD/001/` remains valid
 
-**Important — runs against ALL unmarked workdesk summaries:** the script updates every Supabase row where `journal_date IS NULL`, not just this week's 209. If summaries from prior weeks were never marked, they will all be assigned this week's date. Run this every week to keep state consistent.
+**Scoped by design (hardened 2026-05):** the script no longer blanket-updates every
+`journal_date IS NULL` row — that previously swept un-marked prior weeks into one date
+(caused the 2026-04-25 mega-bucket). It now stamps only the URLs belonging to this
+journal, so leftover backlog is left untouched. If no matching summaries are found it
+**refuses to run** rather than guessing. An `--all-null` escape hatch preserves the old
+blanket behavior for exceptional manual use only.
 
 **When to run:**
 - After archiving journals to `journals/YYYY-MM-DD/`

--- a/scripts/delete_orphans.py
+++ b/scripts/delete_orphans.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Delete true-orphan summary_metadata rows (url in NO journal archive,
+even after normalization). Guarded against bad index builds.
+
+  uv run scripts/delete_orphans.py --apply
+"""
+import os, json, glob, re, sys
+from collections import defaultdict, Counter
+from pathlib import Path
+from dotenv import load_dotenv
+from supabase import create_client
+
+load_dotenv(Path(__file__).parent / ".env")
+sb = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_KEY"))
+apply = (len(sys.argv) == 2 and sys.argv[1] == "--apply")
+
+URLRE = re.compile(r'https?://[^\s\)\]]+')
+def norm(u):
+    if not u: return None
+    u = u.strip().split("#")[0]
+    u = re.sub(r'^https?://', '', u, flags=re.I)
+    u = re.sub(r'^www\.', '', u, flags=re.I)
+    return u.rstrip('/').rstrip('.,;)\'"').lower()
+
+idx = set()
+for f in glob.glob("journals/*/summaries/*.json"):
+    try: c = json.load(open(f)).get("content", {})
+    except Exception: continue
+    for u in (c.get("url"), c.get("contentSourceUrl")):
+        k = norm(u)
+        if k: idx.add(k)
+for f in glob.glob("journals/*/99_unified_summaries.md") + glob.glob("journals/*/sources/sources.md"):
+    try: txt = open(f, encoding="utf-8").read()
+    except Exception: continue
+    for u in URLRE.findall(txt):
+        k = norm(u)
+        if k: idx.add(k)
+
+# SAFETY: index must be healthy or we abort (prevents mass-delete on build failure)
+assert len(idx) > 3000, f"index too small ({len(idx)}) — aborting to avoid mass delete"
+
+rows = []
+start = 0
+while True:
+    r = sb.table("summary_metadata").select("id,url,journal_date").range(start, start+999).execute()
+    rows.extend(r.data)
+    if len(r.data) < 1000: break
+    start += 1000
+
+orphans = [r for r in rows if norm(r["url"]) not in idx]
+print(f"index size: {len(idx)} | total rows: {len(rows)} | true orphans: {len(orphans)}")
+print("by current journal_date:", dict(sorted(Counter(r['journal_date'] or 'NULL' for r in orphans).items())))
+
+# SAFETY: refuse if the orphan set is implausibly large
+assert len(orphans) < 400, f"orphan count {len(orphans)} unexpectedly high — aborting"
+
+print("\n--- rows to delete (audit dump) ---")
+for r in orphans:
+    print(f"{r['id']}\t{r['journal_date']}\t{r['url']}")
+
+if not apply:
+    print(f"\n(dry-run) would delete {len(orphans)} rows. Re-run with --apply.")
+    sys.exit(0)
+
+ids = [r["id"] for r in orphans]
+done = 0
+for i in range(0, len(ids), 100):
+    sb.table("summary_metadata").delete().in_("id", ids[i:i+100]).execute()
+    done += len(ids[i:i+100])
+print(f"\n✅ Deleted {done} orphan rows.")
+
+# verify
+after = sb.table("summary_metadata").select("id", count="exact").limit(1).execute()
+print(f"summary_metadata total now: {after.count}")

--- a/scripts/investigate_supabase.py
+++ b/scripts/investigate_supabase.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""READ-ONLY investigation of summary_metadata journal_date distribution
+and the 2026-04-25 over-count. Makes no writes."""
+import os, sys, json, glob
+from collections import Counter, defaultdict
+from pathlib import Path
+from dotenv import load_dotenv
+from supabase import create_client
+
+load_dotenv(Path(__file__).parent / ".env")
+sb = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_KEY"))
+
+# 1. Build url -> set(journal archive dates) from archived summaries
+url2dates = defaultdict(set)
+for f in glob.glob("journals/*/summaries/*.json"):
+    date = f.split("/")[1]
+    try:
+        c = json.load(open(f)).get("content", {})
+    except Exception:
+        continue
+    for key in ("url",):
+        u = c.get(key)
+        if u:
+            url2dates[u].add(date)
+    # also index alt source url if present (HN-keyed fallbacks)
+    alt = c.get("contentSourceUrl")
+    if alt:
+        url2dates[alt].add(date)
+print(f"Archived summaries indexed: {len(url2dates)} distinct URLs across {len(set(glob.glob('journals/*/summaries')))} dirs")
+
+# 2. Fetch ALL summary_metadata rows (paginated)
+rows = []
+start = 0
+while True:
+    r = sb.table("summary_metadata").select(
+        "id,summary_id,url,journal_date,created_at").range(start, start+999).execute()
+    rows.extend(r.data)
+    if len(r.data) < 1000:
+        break
+    start += 1000
+print(f"Total summary_metadata rows: {len(rows)}")
+
+# 3. Full journal_date distribution
+dist = Counter((row["journal_date"] or "NULL") for row in rows)
+print("\n=== journal_date distribution (all) ===")
+for d, n in sorted(dist.items()):
+    print(f"  {d}: {n}")
+
+# 4. Whole-table health: compare each row's current journal_date to its "correct"
+#    date (the archive whose summaries/ contains the row's url).
+def correct_date(row):
+    ds = url2dates.get(row["url"], set())
+    if not ds:
+        return None  # orphan
+    return sorted(ds)[0]  # (urls map to a single archive in practice)
+
+correct_cnt = 0
+orphan_rows = []
+mismatch = Counter()  # (current, correct) -> n
+true_by_date = Counter()  # correct date -> n (what each journal SHOULD have)
+for row in rows:
+    cur = row["journal_date"] or "NULL"
+    cor = correct_date(row)
+    if cor is None:
+        orphan_rows.append(row); continue
+    true_by_date[cor] += 1
+    if cur == cor:
+        correct_cnt += 1
+    else:
+        mismatch[(cur, cor)] += 1
+
+print(f"\n=== Whole-table health ===")
+print(f"  correctly placed: {correct_cnt}")
+print(f"  mis-placed:       {sum(mismatch.values())}")
+print(f"  orphan (url in no archive): {len(orphan_rows)}")
+
+print("\n=== Mis-placements: current journal_date -> correct date (count) ===")
+for (cur, cor), n in sorted(mismatch.items(), key=lambda x: -x[1]):
+    print(f"  {cur:>12}  ->  {cor:<12}  {n}")
+
+print("\n=== Per-archive: how many Supabase rows SHOULD carry each date (by url) ===")
+for d, n in sorted(true_by_date.items()):
+    print(f"  {d}: {n}")
+
+print(f"\n=== Orphans: {len(orphan_rows)} (url in NO archived journal) ===")
+om = Counter((r['created_at'] or '')[:7] for r in orphan_rows)
+for m, n in sorted(om.items()):
+    print(f"  created {m}: {n}")
+for row in orphan_rows[:10]:
+    print(f"    {row.get('summary_id')}  {(row.get('created_at') or '')[:10]}  jd={row['journal_date']}  {row['url'][:70]}")

--- a/scripts/mark_published.py
+++ b/scripts/mark_published.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """
-Mark workdesk summaries as published by setting their journal_date.
+Mark this week's summaries as published by setting their journal_date.
 
-This script updates all workdesk summaries (journal_date IS NULL) to have
-a specific journal date, indicating they've been published in that week's journal.
+By default this is SCOPED to the current journal's own summaries (matched by
+URL against journals/<date>/summaries/*.json, with a workdesk/ fallback), so
+it can NOT sweep a backlog of unrelated unmarked rows into this week — the bug
+that caused the 2026-04-25 mega-bucket.
 
 Usage:
-    uv run scripts/mark_published.py 2025-12-27
+    uv run scripts/mark_published.py 2026-05-30            # scoped (recommended)
+    uv run scripts/mark_published.py 2026-05-30 --all-null # legacy blanket behavior (escape hatch)
 
 Arguments:
     journal_date: The date of the journal in YYYY-MM-DD format
@@ -14,88 +17,113 @@ Arguments:
 
 import os
 import sys
+import json
+import glob
+import re
 from pathlib import Path
-from typing import List
 from dotenv import load_dotenv
 from supabase import create_client, Client
-import re
 
-# Load environment variables
 load_dotenv(Path(__file__).parent / ".env")
-
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
-
 if not SUPABASE_URL or not SUPABASE_KEY:
     print("Error: SUPABASE_URL and SUPABASE_SERVICE_KEY must be set in scripts/.env")
-    print("See scripts/.env.example for configuration")
     sys.exit(1)
-
-# Initialize Supabase client
 supabase: Client = create_client(SUPABASE_URL, SUPABASE_KEY)
 
 
 def validate_date_format(date_str: str) -> bool:
-    """Validate that date is in YYYY-MM-DD format."""
-    pattern = r'^\d{4}-\d{2}-\d{2}$'
-    return bool(re.match(pattern, date_str))
+    return bool(re.match(r'^\d{4}-\d{2}-\d{2}$', date_str))
 
 
-def mark_as_published(journal_date: str) -> int:
-    """
-    Mark all workdesk summaries as published for the given journal date.
+def norm(u):
+    """Canonicalize a URL for matching (scheme/www/trailing-slash/fragment-insensitive)."""
+    if not u:
+        return None
+    u = u.strip().split("#")[0]
+    u = re.sub(r'^https?://', '', u, flags=re.I)
+    u = re.sub(r'^www\.', '', u, flags=re.I)
+    return u.rstrip('/').rstrip('.,;)\'"').lower()
 
-    Args:
-        journal_date: The journal date in YYYY-MM-DD format
 
-    Returns:
-        Number of summaries updated
-    """
-    # Update all summaries where journal_date is NULL
+def collect_week_urls(journal_date: str):
+    """URLs for THIS journal, from the archived summaries (preferred) or workdesk."""
+    sources = sorted(glob.glob(f"journals/{journal_date}/summaries/*.json")) or \
+        sorted(glob.glob("workdesk/summaries/*.json"))
+    urls = set()
+    for f in sources:
+        try:
+            c = json.load(open(f)).get("content", {})
+        except Exception:
+            continue
+        for u in (c.get("url"), c.get("contentSourceUrl")):
+            k = norm(u)
+            if k:
+                urls.add((k, u))  # keep one raw form for the IN filter
+    return sources, urls
+
+
+def mark_scoped(journal_date: str) -> int:
+    _, week = collect_week_urls(journal_date)
+    if not week:
+        print("❌ Found no summaries for this journal (checked journals/<date>/summaries/ "
+              "and workdesk/summaries/). Refusing to run. Use --all-null to force legacy behavior.")
+        sys.exit(1)
+    # Fetch all rows once; match by normalized URL, then update by id (precise).
+    rows = []
+    start = 0
+    while True:
+        r = supabase.table("summary_metadata").select("id,url,journal_date").range(start, start + 999).execute()
+        rows.extend(r.data)
+        if len(r.data) < 1000:
+            break
+        start += 1000
+    week_norm = {k for k, _ in week}
+    ids = [row["id"] for row in rows
+           if norm(row["url"]) in week_norm and (row["journal_date"] or None) != journal_date]
+    print(f"This journal has {len(week_norm)} distinct URLs; {len(ids)} matching rows need journal_date={journal_date}.")
+    for i in range(0, len(ids), 100):
+        supabase.table("summary_metadata").update({"journal_date": journal_date}).in_("id", ids[i:i + 100]).execute()
+    return len(ids)
+
+
+def mark_all_null(journal_date: str) -> int:
     response = supabase.table("summary_metadata").update(
-        {"journal_date": journal_date}
-    ).is_("journal_date", "null").execute()
-
+        {"journal_date": journal_date}).is_("journal_date", "null").execute()
     return len(response.data) if response.data else 0
 
 
 def main():
-    """Main execution function."""
-    if len(sys.argv) != 2:
-        print("Usage: uv run scripts/mark_published.py YYYY-MM-DD")
-        print("")
-        print("Example:")
-        print("  uv run scripts/mark_published.py 2025-12-27")
+    args = sys.argv[1:]
+    all_null = "--all-null" in args
+    args = [a for a in args if a != "--all-null"]
+    if len(args) != 1:
+        print("Usage: uv run scripts/mark_published.py YYYY-MM-DD [--all-null]")
         sys.exit(1)
-
-    journal_date = sys.argv[1]
-
-    # Validate date format
+    journal_date = args[0]
     if not validate_date_format(journal_date):
-        print(f"❌ Invalid date format: {journal_date}")
-        print("   Date must be in YYYY-MM-DD format")
+        print(f"❌ Invalid date format: {journal_date}  (expected YYYY-MM-DD)")
         sys.exit(1)
 
-    print(f"Marking workdesk summaries as published for journal date: {journal_date}")
+    mode = "ALL journal_date IS NULL rows (legacy blanket)" if all_null \
+        else "only THIS journal's summaries (scoped by URL)"
+    print(f"Marking as published for journal date: {journal_date}")
+    print(f"Mode: {mode}")
+    if all_null:
+        print("⚠️  --all-null can sweep unrelated unmarked rows into this date. Use only intentionally.")
     print("")
-
-    # Confirm with user
-    confirm = input(f"This will set journal_date={journal_date} for ALL workdesk summaries. Continue? (yes/no): ")
-
+    confirm = input(f"Set journal_date={journal_date} for {mode}? Continue? (yes/no): ")
     if confirm.lower() not in ["yes", "y"]:
         print("Cancelled.")
         sys.exit(0)
 
     try:
-        count = mark_as_published(journal_date)
+        count = (mark_all_null if all_null else mark_scoped)(journal_date)
         print(f"\n✅ Successfully marked {count} summaries as published")
         print(f"   Journal date: {journal_date}")
-
         if count == 0:
-            print("\n⚠️  No workdesk summaries found. Either:")
-            print("   - No summaries have been created yet")
-            print("   - All summaries have already been marked as published")
-
+            print("\n⚠️  Nothing to update — summaries may already be marked.")
     except Exception as e:
         print(f"❌ Error: {e}")
         sys.exit(1)

--- a/scripts/remediate_journal_dates.py
+++ b/scripts/remediate_journal_dates.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Re-assign mis-placed summary_metadata rows to the journal_date whose
+archived summaries/ contains the row's URL. Deterministic, by exact row id.
+
+  uv run scripts/remediate_journal_dates.py --dry-run
+  uv run scripts/remediate_journal_dates.py --apply
+"""
+import os, sys, json, glob
+from collections import defaultdict, Counter
+from pathlib import Path
+from dotenv import load_dotenv
+from supabase import create_client
+
+load_dotenv(Path(__file__).parent / ".env")
+sb = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_KEY"))
+
+mode = sys.argv[1] if len(sys.argv) == 2 else None
+if mode not in ("--dry-run", "--apply"):
+    print("Usage: remediate_journal_dates.py [--dry-run|--apply]"); sys.exit(1)
+
+# url -> set(dates) from archived summaries/*.json
+url2dates = defaultdict(set)
+for f in glob.glob("journals/*/summaries/*.json"):
+    date = f.split("/")[1]
+    try:
+        c = json.load(open(f)).get("content", {})
+    except Exception:
+        continue
+    for u in (c.get("url"), c.get("contentSourceUrl")):
+        if u:
+            url2dates[u].add(date)
+
+multi = {u: ds for u, ds in url2dates.items() if len(ds) > 1}
+print(f"Indexed {len(url2dates)} URLs; {len(multi)} map to >1 archive (excluded from auto-fix)")
+
+# fetch all rows
+rows = []
+start = 0
+while True:
+    r = sb.table("summary_metadata").select("id,url,journal_date").range(start, start+999).execute()
+    rows.extend(r.data)
+    if len(r.data) < 1000:
+        break
+    start += 1000
+
+# plan: correct_date -> [ids] for rows whose url maps to exactly one archive != current
+plan = defaultdict(list)
+skipped_multi = 0
+for row in rows:
+    ds = url2dates.get(row["url"], set())
+    if not ds:
+        continue  # orphan -> leave
+    if len(ds) > 1:
+        skipped_multi += 1; continue
+    correct = next(iter(ds))
+    if (row["journal_date"] or None) != correct:
+        plan[correct].append(row["id"])
+
+total = sum(len(v) for v in plan.values())
+print(f"\nPlanned re-assignments: {total} rows (skipped {skipped_multi} multi-mapped)")
+for d, ids in sorted(plan.items()):
+    print(f"  -> {d}: {len(ids)}")
+
+if mode == "--dry-run":
+    print("\n(dry-run) no writes."); sys.exit(0)
+
+confirm = input(f"\nApply {total} journal_date re-assignments to production Supabase? (yes/no): ")
+if confirm.lower() not in ("yes", "y"):
+    print("Cancelled."); sys.exit(0)
+
+done = 0
+for d, ids in sorted(plan.items()):
+    for i in range(0, len(ids), 100):
+        batch = ids[i:i+100]
+        sb.table("summary_metadata").update({"journal_date": d}).in_("id", batch).execute()
+        done += len(batch)
+    print(f"  set {d}: {len(ids)} rows")
+print(f"\n✅ Re-assigned {done} rows.")

--- a/scripts/remediate_orphans.py
+++ b/scripts/remediate_orphans.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Reclassify orphan rows using a NORMALIZED URL index built from
+summaries/*.json + 99_unified_summaries.md (出典) + sources/sources.md.
+Re-assigns rows that deterministically map to one journal; reports the
+true remainder.
+
+  uv run scripts/remediate_orphans.py --dry-run
+  uv run scripts/remediate_orphans.py --apply
+"""
+import os, json, glob, re, sys
+from collections import defaultdict, Counter
+from pathlib import Path
+from dotenv import load_dotenv
+from supabase import create_client
+
+load_dotenv(Path(__file__).parent / ".env")
+sb = create_client(os.getenv("SUPABASE_URL"), os.getenv("SUPABASE_SERVICE_KEY"))
+mode = sys.argv[1] if len(sys.argv) == 2 else None
+if mode not in ("--dry-run", "--apply"):
+    print("Usage: remediate_orphans.py [--dry-run|--apply]"); sys.exit(1)
+
+URLRE = re.compile(r'https?://[^\s\)\]]+')
+
+def norm(u):
+    if not u: return None
+    u = u.strip().split("#")[0]
+    u = re.sub(r'^https?://', '', u, flags=re.I)
+    u = re.sub(r'^www\.', '', u, flags=re.I)
+    u = u.rstrip('/').rstrip('.,;)\'"')
+    return u.lower()
+
+idx = defaultdict(set)  # norm(url) -> {dates}
+# strict: summaries/*.json
+for f in glob.glob("journals/*/summaries/*.json"):
+    d = f.split("/")[1]
+    try: c = json.load(open(f)).get("content", {})
+    except Exception: continue
+    for u in (c.get("url"), c.get("contentSourceUrl")):
+        k = norm(u)
+        if k: idx[k].add(d)
+# legacy: 99_unified 出典 + sources.md
+for f in glob.glob("journals/*/99_unified_summaries.md") + glob.glob("journals/*/sources/sources.md"):
+    d = f.split("/")[1]
+    try: txt = open(f, encoding="utf-8").read()
+    except Exception: continue
+    for u in URLRE.findall(txt):
+        k = norm(u)
+        if k: idx[k].add(d)
+
+rows = []
+start = 0
+while True:
+    r = sb.table("summary_metadata").select("id,url,journal_date").range(start, start+999).execute()
+    rows.extend(r.data);
+    if len(r.data) < 1000: break
+    start += 1000
+
+plan = defaultdict(list); multi = 0; true_orphan = []
+for row in rows:
+    ds = idx.get(norm(row["url"]), set())
+    if not ds:
+        true_orphan.append(row); continue
+    if len(ds) > 1:
+        multi += 1; continue
+    cor = next(iter(ds))
+    if (row["journal_date"] or None) != cor:
+        plan[cor].append(row["id"])
+
+total = sum(len(v) for v in plan.values())
+print(f"Indexed {len(idx)} normalized URLs. Multi-mapped rows skipped: {multi}")
+print(f"\nDeterministic re-assignments (post-normalization): {total}")
+for d, ids in sorted(plan.items()):
+    print(f"  -> {d}: {len(ids)}")
+print(f"\nTrue remaining orphans (no match even normalized): {len(true_orphan)}")
+om = Counter((r['journal_date'] or 'NULL') for r in true_orphan)
+print("  truly-orphan by current journal_date:", dict(sorted(om.items())))
+
+if mode == "--dry-run":
+    print("\n(dry-run) no writes."); sys.exit(0)
+
+confirm = input(f"\nApply {total} re-assignments? (truly-orphan {len(true_orphan)} left untouched) (yes/no): ")
+if confirm.lower() not in ("yes", "y"):
+    print("Cancelled."); sys.exit(0)
+done = 0
+for d, ids in sorted(plan.items()):
+    for i in range(0, len(ids), 100):
+        sb.table("summary_metadata").update({"journal_date": d}).in_("id", ids[i:i+100]).execute()
+        done += len(ids[i:i+100])
+    print(f"  set {d}: {len(ids)}")
+print(f"\n✅ Re-assigned {done}. Truly-orphan remaining (untouched): {len(true_orphan)}")


### PR DESCRIPTION
## Harden `mark_published.py` + add Supabase remediation tools

### Root cause
`mark_published.py` blanket-set **every** `journal_date IS NULL` row to the given date. Any week that wasn't individually published got swept into the next publish — producing the `2026-04-25` (1,258) and `2026-02-28` (865) mega-buckets and leaving 6 journals with zero Supabase rows (broken summary pages).

### Fix
- **`mark_published.py` is now scoped**: it stamps only the URLs belonging to *this* journal (matched against `journals/<date>/summaries/*.json`, `workdesk/` fallback). Leftover backlog is left untouched. Refuses to run if no summaries match. `--all-null` retains the legacy blanket behavior as an explicit escape hatch.
  - Verified: a scoped run on an already-correct journal updates **0** rows (no sweep).
- **Docs** (`CLAUDE.md`, `STEP_10`) updated to describe the scoped behavior.

### New maintenance tools (`scripts/`)
- `investigate_supabase.py` — read-only health check (row's `journal_date` vs the archive containing its URL).
- `remediate_journal_dates.py` — deterministic URL-keyed re-assignment of mis-placed rows.
- `remediate_orphans.py` — normalized re-match incl. legacy `99_unified` archives + orphan detection.
- `delete_orphans.py` — guarded deletion of true orphans (index-size + count safety guards).

### Applied this session (production Supabase)
- 1,431 mis-placed rows → corrected (restored journals 02-14/02-21/03-28/04-04/04-11/04-18)
- 71 legacy orphans → reclassified
- 225 true orphans → deleted
- Net: 3,886 → 3,661 rows; **0 mis-placed / 0 orphans** afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)
