### PR TITLE
Resolve canonical URL via hreflang=x-default before dedup (closes #145)

### DIFF
--- a/STEP_02_GATHER_SOURCES.md
+++ b/STEP_02_GATHER_SOURCES.md
@@ -25,8 +25,16 @@ python3 scripts/check_link.py https://example.com/article-about-ai-coding
 ### What the Check Script Does
 
 1. **Sanitizes the URL** - Removes UTM parameters and fragments
-2. **Checks for duplicates** - Searches in both sources.md and summaries
-3. **Reports status** - Tells you if the URL is unique and ready to add
+2. **Resolves the canonical URL** - Fetches the page and parses `<head>` for
+   `hreflang="x-default"` → `rel="canonical"` → `og:url` (in priority order).
+   If the page declares a different canonical, the dedup check uses that
+   canonical instead. This catches localized variants such as
+   `https://openai.com/ja-JP/index/foo/` resolving to
+   `https://openai.com/index/foo/`, so the same article cannot be added
+   twice under different language paths. Network failures fall back to the
+   sanitized URL (the add is not blocked).
+3. **Checks for duplicates** - Searches in both sources.md and summaries
+4. **Reports status** - Tells you if the URL is unique and ready to add
 
 ## Manual Link Addition Process
 

--- a/scripts/canonicalize_url.py
+++ b/scripts/canonicalize_url.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Resolve the canonical form of a URL by inspecting the page's HTML <head>.
+
+Looks for canonical signals in this priority order:
+  1. <link rel="alternate" hrefLang="x-default" href="...">
+  2. <link rel="canonical" href="...">
+  3. <meta property="og:url" content="...">
+
+This catches the common pattern where a locale-specific URL (e.g.
+https://openai.com/ja-JP/index/foo/) declares an English x-default
+canonical at https://openai.com/index/foo/, so subsequent duplicate
+checks compare the same article under one identity.
+
+Usage as a module:
+    from canonicalize_url import fetch_canonical
+    canonical, source = fetch_canonical("https://openai.com/ja-JP/index/foo/")
+    # canonical -> "https://openai.com/index/foo/"
+    # source    -> "hreflang=x-default"
+
+Usage as a CLI (for debugging / one-off lookups):
+    python3 scripts/canonicalize_url.py <URL>
+"""
+
+import sys
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse
+
+import requests
+from requests.exceptions import RequestException
+
+
+DEFAULT_USER_AGENT = "Mozilla/5.0 (GenAI Journal Link Checker)"
+# Many head sections are well under 32 KiB; bound the response so we don't
+# pull whole articles just to read <head>.
+DEFAULT_RANGE_BYTES = 32768
+DEFAULT_TIMEOUT = 10
+
+
+class _CanonicalHeadParser(HTMLParser):
+    """Extract canonical signals from a document's <head>.
+
+    Records, in document order, the first occurrence of each signal.
+    Stops collecting once <body> opens or </head> closes — anything past
+    the head is irrelevant and may even be a truncated fragment from the
+    Range request.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.x_default: str | None = None
+        self.canonical: str | None = None
+        self.og_url: str | None = None
+        self._in_head = False
+        self._past_head = False
+
+    def handle_starttag(self, tag, attrs):
+        if self._past_head:
+            return
+        tag_lower = tag.lower()
+        if tag_lower == "head":
+            self._in_head = True
+            return
+        if tag_lower == "body":
+            self._in_head = False
+            self._past_head = True
+            return
+        # Some short pages render meta before any explicit <head> (rare but
+        # possible with malformed HTML). Be tolerant: also accept tags at the
+        # top of the document until we hit <body>.
+        if not self._in_head and not self._past_head:
+            pass  # accept top-of-document tags too
+        elif not self._in_head:
+            return
+        attrs_dict = {k.lower(): (v or "") for k, v in attrs}
+
+        if tag_lower == "link":
+            rel = attrs_dict.get("rel", "").lower().strip()
+            hreflang = attrs_dict.get("hreflang", "").lower().strip()
+            href = attrs_dict.get("href", "").strip()
+            if not href:
+                return
+            if rel == "alternate" and hreflang == "x-default":
+                if self.x_default is None:
+                    self.x_default = href
+            elif rel == "canonical":
+                if self.canonical is None:
+                    self.canonical = href
+        elif tag_lower == "meta":
+            prop = attrs_dict.get("property", "").lower().strip()
+            content = attrs_dict.get("content", "").strip()
+            if prop == "og:url" and content and self.og_url is None:
+                self.og_url = content
+
+    def handle_endtag(self, tag):
+        if tag.lower() == "head":
+            self._past_head = True
+            self._in_head = False
+
+
+def parse_canonical_signals(
+    html_text: str,
+    base_url: str,
+) -> tuple[str | None, str | None]:
+    """Parse canonical signals from HTML text.
+
+    Returns (canonical_url, source_label) where source_label is one of
+    "hreflang=x-default", "rel=canonical", "og:url", or (None, None) if
+    no signal is present. Relative hrefs are resolved against base_url.
+
+    Exposed for testability: tests can feed fixture HTML directly without
+    hitting the network.
+    """
+    parser = _CanonicalHeadParser()
+    try:
+        parser.feed(html_text)
+    except Exception:
+        # html.parser can raise on edge-case malformed input; tolerate and
+        # work with whatever we collected before the error.
+        pass
+
+    candidates = [
+        ("hreflang=x-default", parser.x_default),
+        ("rel=canonical", parser.canonical),
+        ("og:url", parser.og_url),
+    ]
+    for source, href in candidates:
+        if not href:
+            continue
+        resolved = urljoin(base_url, href)
+        # Sanity-check: must be http(s).
+        scheme = urlparse(resolved).scheme.lower()
+        if scheme not in ("http", "https"):
+            continue
+        return resolved, source
+    return None, None
+
+
+def fetch_canonical(
+    url: str,
+    timeout: int = DEFAULT_TIMEOUT,
+    user_agent: str = DEFAULT_USER_AGENT,
+    range_bytes: int = DEFAULT_RANGE_BYTES,
+) -> tuple[str | None, str | None]:
+    """Fetch the URL's <head> and resolve its canonical URL.
+
+    Returns (canonical_url, source_label) where source_label identifies
+    which signal was used, or (None, None) on any of:
+      - network failure / timeout
+      - non-success HTTP status
+      - no canonical signals present
+      - canonical scheme is not http(s)
+
+    The canonical is NOT compared against `url` here; the caller decides
+    whether the swap is a no-op (e.g. after re-sanitization). This keeps
+    self-reference policy out of the helper and in check_link.py where
+    sanitization rules live.
+    """
+    headers = {
+        "User-Agent": user_agent,
+        "Accept": "text/html,application/xhtml+xml,*/*;q=0.8",
+        # Range as a hint; servers that ignore it just return the full body,
+        # which we'll truncate ourselves.
+        "Range": f"bytes=0-{range_bytes}",
+    }
+    try:
+        response = requests.get(
+            url,
+            allow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+            stream=False,
+        )
+    except RequestException:
+        return None, None
+
+    # 2xx and 206 (Partial Content) are both fine. Treat 3xx oddly-stuck as ok
+    # since requests has already followed allow_redirects=True.
+    if response.status_code >= 400:
+        return None, None
+
+    # Be safe even if the server ignored the Range header.
+    text = response.text[: range_bytes * 2] if response.text else ""
+    if not text:
+        return None, None
+
+    # Use response.url (post-redirect) as the base for relative href
+    # resolution — that's what a browser would do for a <link href="/foo">.
+    return parse_canonical_signals(text, response.url)
+
+
+def _cli() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python3 scripts/canonicalize_url.py <URL>", file=sys.stderr)
+        return 1
+    url = sys.argv[1]
+    canonical, source = fetch_canonical(url)
+    if canonical:
+        print(f"Input:     {url}")
+        print(f"Canonical: {canonical}  (from {source})")
+        return 0
+    print(f"No canonical URL found for: {url}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/scripts/check_link.py
+++ b/scripts/check_link.py
@@ -4,8 +4,10 @@ Check a link before adding to the GenAI journal workflow.
 This script:
 1. Accepts a URL as input
 2. Sanitizes the URL (removes UTM params and fragments)
-3. Follows HTTP redirects to get the final destination URL
-4. Checks for duplicates in existing summaries (both original and final URLs)
+3. Resolves the canonical URL via HTML <head> signals
+   (hreflang=x-default → rel=canonical → og:url)
+4. Follows HTTP redirects to get the final destination URL
+5. Checks for duplicates in existing summaries (using the canonical URL)
 """
 
 import sys
@@ -15,6 +17,11 @@ from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 from pathlib import Path
 import requests
 from requests.exceptions import RequestException
+
+# Allow `python3 scripts/check_link.py ...` to import the sibling helper
+# without requiring scripts/ to be on PYTHONPATH.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from canonicalize_url import fetch_canonical  # noqa: E402
 
 def validate_url(url):
     """
@@ -215,9 +222,34 @@ def main():
     if url != sanitized_url:
         print("Note: URL was modified (removed tracking params/fragments)")
 
+    # Step 2.5: Resolve canonical URL via HTML head signals
+    # (hreflang=x-default → rel=canonical → og:url).
+    # If the page declares a different canonical, switch to it before
+    # the dedup check — that catches localized variants like
+    # https://openai.com/ja-JP/index/foo/  →  https://openai.com/index/foo/.
+    print("\nResolving canonical URL...")
+    canonical_url, canonical_source = fetch_canonical(sanitized_url)
+    dedup_url = sanitized_url
+    if canonical_url:
+        canonical_sanitized = sanitize_url(canonical_url)
+        if canonical_sanitized != sanitized_url:
+            print(
+                f"Input:     {sanitized_url}\n"
+                f"Canonical: {canonical_sanitized}  (from {canonical_source})"
+            )
+            dedup_url = canonical_sanitized
+        else:
+            # Self-referencing canonical (page declared itself) — no-op.
+            print(
+                f"Canonical matches input (self-referencing {canonical_source}); "
+                "no swap."
+            )
+    else:
+        print("No canonical signal found; using sanitized URL for dedup.")
+
     # Step 3: Follow redirects
     print("\nFollowing redirects...")
-    final_url, redirect_chain = follow_redirects(sanitized_url)
+    final_url, redirect_chain = follow_redirects(dedup_url)
 
     if final_url:
         if redirect_chain:
@@ -227,20 +259,20 @@ def main():
                 print(f"  {i}. {redirect_url}")
         else:
             print(f"No redirects detected")
-            final_url = sanitized_url
+            final_url = dedup_url
     else:
         print("Warning: Unable to follow redirects (network error or timeout)")
-        print("Will check for duplicates using sanitized URL only")
+        print("Will check for duplicates using sanitized/canonical URL only")
         final_url = None
 
-    # Step 4: Check for duplicates (both sanitized and final URLs)
-    is_duplicate, duplicates = check_duplicate(sanitized_url, final_url)
+    # Step 4: Check for duplicates (the dedup URL plus any redirect destination)
+    is_duplicate, duplicates = check_duplicate(dedup_url, final_url)
 
     if is_duplicate:
         print(f"\n❌ Error: URL already exists!")
         print("\nDuplicates found:")
         for location, matched_url in duplicates:
-            if matched_url != sanitized_url:
+            if matched_url != dedup_url:
                 print(f"  - {location}")
                 print(f"    Matched via redirect: {matched_url}")
             else:

--- a/scripts/test_canonicalize_url.py
+++ b/scripts/test_canonicalize_url.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Tests for canonicalize_url.
+
+Run:
+    python3 scripts/test_canonicalize_url.py
+    # or:
+    uv run scripts/test_canonicalize_url.py
+
+All tests are offline — parse_canonical_signals takes raw HTML, and
+fetch_canonical is exercised by injecting a fake `requests.get` via
+unittest.mock so we never hit the network.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from canonicalize_url import (  # noqa: E402
+    fetch_canonical,
+    parse_canonical_signals,
+)
+
+
+class _FakeResponse:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(self, *, text: str, status_code: int = 200, final_url: str | None = None):
+        self.text = text
+        self.status_code = status_code
+        # When the server redirects to an English landing page, response.url
+        # reflects the post-redirect URL — relative hrefs must resolve against it.
+        self.url = final_url
+
+
+# ---------------------------------------------------------------------------
+# parse_canonical_signals — pure parser tests
+# ---------------------------------------------------------------------------
+
+class ParseCanonicalSignalsTests(unittest.TestCase):
+    def test_x_default_wins_over_canonical_and_og(self):
+        html = """
+        <html><head>
+          <link rel="alternate" hrefLang="x-default" href="https://example.com/en/foo/">
+          <link rel="canonical" href="https://example.com/ja-jp/foo/">
+          <meta property="og:url" content="https://example.com/og-foo/">
+        </head><body></body></html>
+        """
+        url, source = parse_canonical_signals(html, "https://example.com/ja-jp/foo/")
+        self.assertEqual(url, "https://example.com/en/foo/")
+        self.assertEqual(source, "hreflang=x-default")
+
+    def test_canonical_used_when_no_x_default(self):
+        html = """
+        <html><head>
+          <link rel="canonical" href="https://example.com/en/foo/">
+          <meta property="og:url" content="https://example.com/og-foo/">
+        </head></html>
+        """
+        url, source = parse_canonical_signals(html, "https://example.com/ja-jp/foo/")
+        self.assertEqual(url, "https://example.com/en/foo/")
+        self.assertEqual(source, "rel=canonical")
+
+    def test_og_url_used_when_canonical_missing(self):
+        html = """
+        <html><head>
+          <meta property="og:url" content="https://example.com/en/foo/">
+        </head></html>
+        """
+        url, source = parse_canonical_signals(html, "https://example.com/ja-jp/foo/")
+        self.assertEqual(url, "https://example.com/en/foo/")
+        self.assertEqual(source, "og:url")
+
+    def test_no_signals_returns_none(self):
+        html = "<html><head><title>foo</title></head></html>"
+        url, source = parse_canonical_signals(html, "https://example.com/foo/")
+        self.assertIsNone(url)
+        self.assertIsNone(source)
+
+    def test_relative_href_resolves_against_base(self):
+        html = """
+        <html><head>
+          <link rel="canonical" href="/en/foo/">
+        </head></html>
+        """
+        url, source = parse_canonical_signals(html, "https://example.com/ja-jp/foo/")
+        self.assertEqual(url, "https://example.com/en/foo/")
+        self.assertEqual(source, "rel=canonical")
+
+    def test_non_http_scheme_skipped(self):
+        # If the only candidate is javascript: or mailto:, treat as no signal.
+        html = """
+        <html><head>
+          <link rel="canonical" href="javascript:void(0)">
+        </head></html>
+        """
+        url, source = parse_canonical_signals(html, "https://example.com/foo/")
+        self.assertIsNone(url)
+        self.assertIsNone(source)
+
+    def test_cross_domain_canonical_is_kept(self):
+        # Per issue #145: syndicated posts may point at a different domain
+        # (Medium → personal blog). We should surface the canonical and let
+        # the caller decide.
+        html = """
+        <html><head>
+          <link rel="canonical" href="https://author.example/originals/foo/">
+        </head></html>
+        """
+        url, source = parse_canonical_signals(
+            html, "https://medium.com/@author/foo-abc123"
+        )
+        self.assertEqual(url, "https://author.example/originals/foo/")
+        self.assertEqual(source, "rel=canonical")
+
+    def test_amp_canonical_to_desktop(self):
+        # Per issue #145: /amp/ pages typically canonical-point at the desktop URL.
+        html = """
+        <html><head>
+          <link rel="canonical" href="https://news.example/article/123/">
+        </head></html>
+        """
+        url, source = parse_canonical_signals(
+            html, "https://news.example/article/123/amp/"
+        )
+        self.assertEqual(url, "https://news.example/article/123/")
+        self.assertEqual(source, "rel=canonical")
+
+    def test_signals_outside_head_ignored(self):
+        # A canonical-like tag in <body> shouldn't be picked up (avoids the
+        # rare case where article body contains structured-data fragments).
+        html = """
+        <html>
+          <head><title>page</title></head>
+          <body>
+            <link rel="canonical" href="https://wrong.example/">
+          </body>
+        </html>
+        """
+        url, source = parse_canonical_signals(html, "https://example.com/foo/")
+        self.assertIsNone(url)
+        self.assertIsNone(source)
+
+    def test_first_x_default_wins(self):
+        # If a page declares multiple x-default alternates (multilingual sites
+        # occasionally do this by mistake), take the first.
+        html = """
+        <html><head>
+          <link rel="alternate" hrefLang="x-default" href="https://example.com/en/foo/">
+          <link rel="alternate" hrefLang="x-default" href="https://example.com/de/foo/">
+        </head></html>
+        """
+        url, _ = parse_canonical_signals(html, "https://example.com/ja-jp/foo/")
+        self.assertEqual(url, "https://example.com/en/foo/")
+
+    def test_self_referencing_canonical_returned_as_is(self):
+        # parse_canonical_signals doesn't enforce self-reference policy —
+        # that's check_link.py's job (it re-sanitizes and compares).
+        html = """
+        <html><head>
+          <link rel="canonical" href="https://example.com/foo/">
+        </head></html>
+        """
+        url, source = parse_canonical_signals(html, "https://example.com/foo/")
+        self.assertEqual(url, "https://example.com/foo/")
+        self.assertEqual(source, "rel=canonical")
+
+
+# ---------------------------------------------------------------------------
+# fetch_canonical — network behavior tests (via mocked requests.get)
+# ---------------------------------------------------------------------------
+
+class FetchCanonicalTests(unittest.TestCase):
+    @patch("canonicalize_url.requests.get")
+    def test_openai_localized_returns_english_canonical(self, mock_get):
+        # The motivating example from issue #145: localized OpenAI page
+        # declares its English canonical via hreflang=x-default.
+        html = """
+        <html><head>
+          <link rel="alternate" hrefLang="x-default"
+                href="https://openai.com/index/frontier-safety-blueprint/">
+          <link rel="alternate" hrefLang="en"
+                href="https://openai.com/index/frontier-safety-blueprint/">
+          <link rel="canonical"
+                href="https://openai.com/ja-JP/index/frontier-safety-blueprint/">
+        </head></html>
+        """
+        mock_get.return_value = _FakeResponse(
+            text=html,
+            status_code=206,
+            final_url="https://openai.com/ja-JP/index/frontier-safety-blueprint/",
+        )
+        url, source = fetch_canonical(
+            "https://openai.com/ja-JP/index/frontier-safety-blueprint/"
+        )
+        self.assertEqual(
+            url, "https://openai.com/index/frontier-safety-blueprint/"
+        )
+        self.assertEqual(source, "hreflang=x-default")
+
+    @patch("canonicalize_url.requests.get")
+    def test_network_failure_returns_none_none(self, mock_get):
+        # Per issue: fall back gracefully on network failure.
+        from requests.exceptions import ConnectionError
+
+        mock_get.side_effect = ConnectionError("boom")
+        url, source = fetch_canonical("https://example.com/foo/")
+        self.assertIsNone(url)
+        self.assertIsNone(source)
+
+    @patch("canonicalize_url.requests.get")
+    def test_404_returns_none_none(self, mock_get):
+        mock_get.return_value = _FakeResponse(text="not found", status_code=404)
+        url, source = fetch_canonical("https://example.com/foo/")
+        self.assertIsNone(url)
+        self.assertIsNone(source)
+
+    @patch("canonicalize_url.requests.get")
+    def test_empty_body_returns_none_none(self, mock_get):
+        mock_get.return_value = _FakeResponse(
+            text="", status_code=200, final_url="https://example.com/foo/"
+        )
+        url, source = fetch_canonical("https://example.com/foo/")
+        self.assertIsNone(url)
+        self.assertIsNone(source)
+
+    @patch("canonicalize_url.requests.get")
+    def test_relative_href_uses_post_redirect_base(self, mock_get):
+        # If a request to /ja-jp/foo/ followed a redirect to /jp/foo/ and then
+        # the body declared <link rel="canonical" href="/foo/">, the canonical
+        # should resolve against the post-redirect URL.
+        html = """
+        <html><head>
+          <link rel="canonical" href="/foo/">
+        </head></html>
+        """
+        mock_get.return_value = _FakeResponse(
+            text=html,
+            status_code=200,
+            final_url="https://example.com/jp/foo/",
+        )
+        url, source = fetch_canonical("https://example.com/ja-jp/foo/")
+        self.assertEqual(url, "https://example.com/foo/")
+        self.assertEqual(source, "rel=canonical")
+
+
+# ---------------------------------------------------------------------------
+# Dedup integration scenario — proves the issue #145 acceptance test:
+# "localized variant of an existing URL is correctly flagged as duplicate"
+# ---------------------------------------------------------------------------
+
+class DedupScenarioTest(unittest.TestCase):
+    """End-to-end shape: a localized URL must dedup against an English URL
+    already in sources by virtue of resolving to the same canonical."""
+
+    @patch("canonicalize_url.requests.get")
+    def test_localized_variant_resolves_to_same_canonical_as_english(self, mock_get):
+        # Imagine: English URL was added in a previous cycle. New cycle:
+        # someone tries to add the ja-JP URL. fetch_canonical on the ja-JP
+        # URL should return the English canonical, which will match the
+        # existing entry under string equality.
+        english = "https://openai.com/index/frontier-safety-blueprint/"
+        ja = "https://openai.com/ja-JP/index/frontier-safety-blueprint/"
+        html_ja = f"""
+        <html><head>
+          <link rel="alternate" hrefLang="x-default" href="{english}">
+          <link rel="canonical" href="{ja}">
+        </head></html>
+        """
+        mock_get.return_value = _FakeResponse(
+            text=html_ja, status_code=200, final_url=ja
+        )
+        canonical, source = fetch_canonical(ja)
+        self.assertEqual(canonical, english)
+        self.assertEqual(source, "hreflang=x-default")
+        # And the canonical is NOT the input — so check_link.py would swap.
+        self.assertNotEqual(canonical, ja)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #145.

## Summary
`check_link.py` (via the new `scripts/canonicalize_url.py` helper) now inspects each candidate URL's HTML `<head>` for canonical signals and uses the declared canonical for dedup. This catches localized variants like the OpenAI ja-JP / Anthropic /ja/ / Microsoft /ja-jp/ pages that previously slipped past string-equality dedup.

Priority order from issue #145:
1. `<link rel="alternate" hrefLang="x-default" href="...">`
2. `<link rel="canonical" href="...">`
3. `<meta property="og:url" content="...">`

## Changes
- **`scripts/canonicalize_url.py`** (new) — `fetch_canonical(url)` does a `GET` with `Range: bytes=0-32768`, parses the head with stdlib `html.parser` (no new dependency), resolves relative hrefs against the post-redirect URL, rejects non-http(s) schemes, and falls back to `(None, None)` on any failure. `parse_canonical_signals(html, base)` is exposed for offline test injection.
- **`scripts/check_link.py`** — between Step 2 (sanitize) and Step 3 (follow redirects), call `fetch_canonical`. Re-sanitize the canonical and swap if it differs from the input; print the swap (or "self-referencing, no-op") so the operator can audit it. Dedup and redirect-following both use the canonical going forward.
- **`scripts/test_canonicalize_url.py`** (new) — 17 offline unit tests covering parser priority, AMP-to-desktop, cross-domain canonical, relative-href resolution, network failure, 404, empty body, and the issue's motivating OpenAI ja-JP example.
- **`STEP_02_GATHER_SOURCES.md`** — documents the resolution step in "What the Check Script Does", including the priority order and the graceful network-failure fallback.

## Acceptance criteria
- [x] `check_link.py` resolves canonical via x-default / rel=canonical / og:url
- [x] Duplicate detection runs on the canonical URL
- [x] CLI output shows the swap when one occurs
- [x] Tests: localized variant of an existing URL is correctly flagged as duplicate (`DedupScenarioTest.test_localized_variant_resolves_to_same_canonical_as_english`)
- [x] Documentation in `STEP_02_GATHER_SOURCES.md` mentions the behavior

## Test plan
- [x] `uv run python scripts/test_canonicalize_url.py -v` — 17/17 pass offline
- [ ] On the next sources cycle, try adding `https://openai.com/ja-JP/index/frontier-safety-blueprint/` after the English canonical is in `sources.md` — should be flagged as a duplicate via `hreflang=x-default`
- [ ] Try a known self-referencing page (e.g. a typical blog post) and confirm the CLI prints "Canonical matches input (self-referencing rel=canonical); no swap." rather than swapping
- [ ] Try a page that has no canonical at all and confirm the script falls through to "No canonical signal found; using sanitized URL for dedup."

## Out of scope
Per the issue's open questions, a backfill pass over `workdesk/summaries/*.json` and `journals/*/sources/*.md` to detect already-archived dupes is deferred to a follow-up. Open an issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)