### PR TITLE
Platform: summarization events log — audit trail, /admin/logs, inbox panel (#172)

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -17,14 +17,18 @@ functions/            Pages Functions = the HTTP API
   _lib/summaries.ts   THE write path: validation, blocked-stub detect, upsert, NNN allocation
   _lib/util.ts        URL sanitize/validate (mirrors scripts/check_link.py)
   _lib/enqueue.ts     kick the summarization DO
+  _lib/events.ts      logEvent(): fire-and-forget audit-trail INSERT (#172),
+                      shared with the pipeline DO
   api/links/          POST (submit+auto-enqueue), GET, PATCH /:id (retry re-enqueues;
                       dismiss RETRACTS the link's workdesk summary — NNN stays spent)
   api/summaries/      POST bulk upsert (fallback pushes), GET list / :id (public reads)
   api/cycle.ts        GET registry state, POST rollover (seed counter per #165 rule)
   api/pipeline.ts     joined operational view for the console
+  api/events.ts       GET audit trail: ?limit= (≤200) &event= &summary_id= &link_id=
 public/               static, Access-protected where sensitive
-  submit/ inbox/      link intake UI + bookmarklet
+  submit/ inbox/      link intake UI + bookmarklet (+ latest-events panel)
   admin/pipeline/     operations console: states, errors, metrics, retry, rollover
+  admin/logs/         events log: full audit trail, filterable, auto-refresh
 worker/               companion Worker "gen-ai-journal-pipeline"
   src/index.ts        SummarizerDO: alarm-driven queue (debounce 20s, serial,
                       stale-claim recovery, infra-retry via alarm backoff)
@@ -64,4 +68,9 @@ wrangler tail gen-ai-journal-pipeline                     # live structured run 
   Re-open flips it back instantly — no regeneration, no token spend.
 - Blocked = fail-closed with a reason on the link; PDFs & bot-blocked pages
   are regenerated locally and pushed (#168, permanent fallback path).
+- Every summarization-lifecycle interaction lands in the append-only `events`
+  table (#172): link submitted/dismissed/reopened, summary created/dismissed/
+  restored, pipeline blocked (with metrics), cycle rolled. Events survive link
+  deletion; scope is summarization only until the publish phase (#163) adds
+  journal events. View at `/admin/logs`, query via `GET /api/events`.
 - Secrets: `API_BEARER_TOKEN` (Pages + worker), `GEMINI_API_KEY` (worker).

--- a/platform/functions/_lib/events.ts
+++ b/platform/functions/_lib/events.ts
@@ -1,0 +1,23 @@
+// Events audit trail (#172): one INSERT helper shared by the Pages Functions
+// and the pipeline DO (which imports across the boundary, like summaries.ts).
+// Fire-and-forget: the audit trail must never break the operation it records,
+// so logEvent swallows every error. Reads live in /api/events.
+
+export interface EventInput {
+  actor: "editor" | "pipeline" | "system";
+  event: string; // link.submitted | link.dismissed | link.reopened | summary.created | summary.dismissed | summary.restored | pipeline.blocked | cycle.rolled
+  linkId?: number | null;
+  summaryId?: string | null;
+  detail?: Record<string, unknown> | null;
+}
+
+export async function logEvent(db: D1Database, e: EventInput): Promise<void> {
+  try {
+    await db
+      .prepare("INSERT INTO events (actor, event, link_id, summary_id, detail) VALUES (?, ?, ?, ?, ?)")
+      .bind(e.actor, e.event, e.linkId ?? null, e.summaryId ?? null, e.detail ? JSON.stringify(e.detail) : null)
+      .run();
+  } catch (err) {
+    console.log(JSON.stringify({ evt: "logEvent.failed", event: e.event, error: String(err).slice(0, 200) }));
+  }
+}

--- a/platform/functions/api/cycle.ts
+++ b/platform/functions/api/cycle.ts
@@ -3,6 +3,7 @@
 //   POST: rollover {date, next_id?} (bearer/Access)
 
 import { authorize, type Env } from "../_lib/auth";
+import { logEvent } from "../_lib/events";
 import { error, json } from "../_lib/util";
 import { getCycle } from "../_lib/summaries";
 
@@ -37,5 +38,6 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
       "INSERT INTO settings (key, value) VALUES ('next_summary_id', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
     ).bind(String(nextId)),
   ]);
+  await logEvent(env.DB, { actor: "editor", event: "cycle.rolled", detail: { date, next_id: nextId, by: who } });
   return json({ active: true, journal_date: date, next_summary_id: nextId });
 };

--- a/platform/functions/api/events.ts
+++ b/platform/functions/api/events.ts
@@ -1,0 +1,41 @@
+// GET /api/events (#172) — the summarization audit trail, newest-first.
+//   ?limit=       default 50, max 200
+//   ?event=       exact event name (e.g. pipeline.blocked)
+//   ?summary_id=  full history for one NNN
+//   ?link_id=     full history for one link
+
+import { authorize, type Env } from "../_lib/auth";
+import { error, json } from "../_lib/util";
+
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+  const who = await authorize(request, env);
+  if (!who) return error("unauthorized", 401);
+
+  const q = new URL(request.url).searchParams;
+  const limit = Math.min(Math.max(Number(q.get("limit") ?? "") || 50, 1), 200);
+  const conds: string[] = [];
+  const binds: (string | number)[] = [];
+  const event = q.get("event");
+  if (event) {
+    conds.push("event = ?");
+    binds.push(event);
+  }
+  const summaryId = q.get("summary_id");
+  if (summaryId) {
+    conds.push("summary_id = ?");
+    binds.push(summaryId);
+  }
+  const linkId = q.get("link_id");
+  if (linkId) {
+    if (!/^\d+$/.test(linkId)) return error("link_id must be an integer", 400);
+    conds.push("link_id = ?");
+    binds.push(Number(linkId));
+  }
+  const where = conds.length ? ` WHERE ${conds.join(" AND ")}` : "";
+  const { results } = await env.DB.prepare(
+    `SELECT id, ts, actor, event, link_id, summary_id, detail FROM events${where} ORDER BY id DESC LIMIT ?`,
+  )
+    .bind(...binds, limit)
+    .all();
+  return json({ events: results, count: results.length });
+};

--- a/platform/functions/api/links/[id].ts
+++ b/platform/functions/api/links/[id].ts
@@ -4,6 +4,7 @@
 
 import { authorize, type Env } from "../../_lib/auth";
 import { enqueueSummarization } from "../../_lib/enqueue";
+import { logEvent } from "../../_lib/events";
 import { error, json } from "../../_lib/util";
 
 export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params, waitUntil }) => {
@@ -31,12 +32,27 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params,
     .first<{ id: number; url: string; status: string; summary_id: string | null }>();
   if (!res) return error("link not found", 404);
 
-  if (status === "dismissed" && res.summary_id) {
-    // Dismiss is a reversible flag — the summary row stays, marked dismissed.
-    // Published rows are never touched.
-    await env.DB.prepare("UPDATE summaries SET status = 'dismissed' WHERE id = ? AND journal_date IS NULL AND status = 'workdesk'")
-      .bind(res.summary_id)
-      .run();
+  if (status === "dismissed") {
+    let flagged = null;
+    if (res.summary_id) {
+      // Dismiss is a reversible flag — the summary row stays, marked dismissed.
+      // Published rows are never touched.
+      flagged = await env.DB.prepare(
+        "UPDATE summaries SET status = 'dismissed' WHERE id = ? AND journal_date IS NULL AND status = 'workdesk' RETURNING id",
+      )
+        .bind(res.summary_id)
+        .first();
+    }
+    await logEvent(env.DB, {
+      actor: "editor",
+      event: "link.dismissed",
+      linkId: id,
+      summaryId: res.summary_id,
+      detail: { url: res.url, by: who },
+    });
+    if (flagged) {
+      await logEvent(env.DB, { actor: "editor", event: "summary.dismissed", linkId: id, summaryId: res.summary_id, detail: { by: who } });
+    }
   }
   if (status === "new") {
     if (res.summary_id) {
@@ -48,9 +64,18 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params,
         .first();
       if (flipped) {
         await env.DB.prepare("UPDATE links SET status = 'summarized' WHERE id = ?").bind(id).run();
+        await logEvent(env.DB, { actor: "editor", event: "link.reopened", linkId: id, summaryId: res.summary_id, detail: { url: res.url, by: who } });
+        await logEvent(env.DB, { actor: "editor", event: "summary.restored", linkId: id, summaryId: res.summary_id, detail: { by: who } });
         return json({ ...res, status: "summarized" });
       }
     }
+    await logEvent(env.DB, {
+      actor: "editor",
+      event: "link.reopened",
+      linkId: id,
+      summaryId: res.summary_id,
+      detail: { url: res.url, by: who, requeued: true },
+    });
     const kick = enqueueSummarization(env); // blocked/never-summarized: real retry
     if (kick) waitUntil(kick);
   }

--- a/platform/functions/api/links/index.ts
+++ b/platform/functions/api/links/index.ts
@@ -4,6 +4,7 @@
 
 import { authorize, type Env } from "../../_lib/auth";
 import { enqueueSummarization } from "../../_lib/enqueue";
+import { logEvent } from "../../_lib/events";
 import { error, json, sanitizeUrl, validateUrl } from "../../_lib/util";
 
 const VALID_STATUSES = ["new", "queued", "summarized", "blocked", "dismissed"] as const;
@@ -36,6 +37,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env, waitUnti
   const res = await env.DB.prepare("INSERT INTO links (url, note) VALUES (?, ?) RETURNING id, submitted_at")
     .bind(url, note)
     .first<{ id: number; submitted_at: string }>();
+  await logEvent(env.DB, { actor: "editor", event: "link.submitted", linkId: res!.id, detail: { url, by: who } });
   const enqueue = enqueueSummarization(env);
   if (enqueue) waitUntil(enqueue);
   return json({ duplicate: false, id: res!.id, url, note, status: "new", submitted_at: res!.submitted_at }, 201);

--- a/platform/migrations/0008_events.sql
+++ b/platform/migrations/0008_events.sql
@@ -1,0 +1,16 @@
+-- Events audit trail (#172): every summarization-lifecycle interaction —
+-- human or pipeline — recorded durably. Scope (per issue declaration):
+-- link lifecycle, pipeline runs, summary flag flips, cycle rollovers.
+-- Future journal events (rebuilds/publishes) arrive with #163.
+-- Append-only: link rows may be deleted, their events stay.
+CREATE TABLE events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  actor       TEXT NOT NULL,   -- 'editor' | 'pipeline' | 'system'
+  event       TEXT NOT NULL,   -- e.g. link.submitted, summary.created, pipeline.blocked
+  link_id     INTEGER,         -- subject link id, when applicable
+  summary_id  TEXT,            -- subject NNN, when applicable
+  detail      TEXT             -- JSON: reason, model, fetch_ms, ai_ms, tokens, …
+);
+CREATE INDEX idx_events_ts ON events (ts DESC);
+CREATE INDEX idx_events_summary ON events (summary_id);

--- a/platform/public/admin/logs/index.html
+++ b/platform/public/admin/logs/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Events log — gen-ai-journal</title>
+  <style>
+    :root { --accent: #d96b0b; --line: #ddd8ce; --muted: #6a6f7a; --ok: #22633c; --bad: #a33326; }
+    body { font-family: system-ui, sans-serif; max-width: 980px; margin: 5vh auto; padding: 0 20px 60px; color: #21252d; line-height: 1.5; }
+    h1 { font-size: 22px; margin: 0 0 4px; }
+    p.sub { color: var(--muted); margin: 0 0 18px; font-size: 14px; }
+    .bar { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 14px; }
+    .bar select, .bar button { font-size: 13px; border: 1px solid var(--line); background: #fff; border-radius: 5px; padding: 5px 12px; }
+    .bar button { cursor: pointer; }
+    .bar .hint { font-size: 12px; color: var(--muted); }
+    table { border-collapse: collapse; width: 100%; font-size: 13px; }
+    th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); padding: 8px 10px; border-bottom: 2px solid var(--line); white-space: nowrap; }
+    td { padding: 7px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
+    td.ts { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--muted); }
+    .pill { font-size: 11px; padding: 1px 9px; border-radius: 20px; background: #eee; white-space: nowrap; }
+    .pill.editor { background: #e8eef5; color: #33567a; }
+    .pill.pipeline { background: #fdf3e4; color: #8a5307; }
+    .pill.system { background: #f0f0ee; color: #888; }
+    .ev { font-family: ui-monospace, monospace; font-size: 12px; white-space: nowrap; }
+    .ev.good { color: var(--ok); }
+    .ev.bad { color: var(--bad); }
+    .subj { white-space: nowrap; }
+    .subj a { color: #1f4e79; }
+    .detail { color: #444; font-size: 12.5px; word-break: break-word; }
+    .tbl-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 6px; background: #fff; }
+    #empty { color: var(--muted); font-size: 14px; padding: 22px 12px; }
+    nav { margin-top: 22px; font-size: 13.5px; }
+    nav a { color: var(--accent); margin-right: 16px; }
+  </style>
+</head>
+<body>
+  <h1>Events log</h1>
+  <p class="sub">Summarization audit trail — every human &amp; pipeline interaction, newest first. <span id="asof"></span></p>
+
+  <div class="bar">
+    <select id="f-event">
+      <option value="">all events</option>
+      <option>link.submitted</option>
+      <option>link.dismissed</option>
+      <option>link.reopened</option>
+      <option>summary.created</option>
+      <option>summary.dismissed</option>
+      <option>summary.restored</option>
+      <option>pipeline.blocked</option>
+      <option>cycle.rolled</option>
+    </select>
+    <select id="f-limit">
+      <option value="50">last 50</option>
+      <option value="100">last 100</option>
+      <option value="200">last 200</option>
+    </select>
+    <span style="flex:1"></span>
+    <span class="hint">auto-refreshes every 30s</span>
+    <button id="refresh">↻ refresh</button>
+  </div>
+
+  <div class="tbl-wrap">
+    <table>
+      <thead><tr><th>time (UTC)</th><th>actor</th><th>event</th><th>subject</th><th>detail</th></tr></thead>
+      <tbody id="rows"></tbody>
+    </table>
+    <div id="empty" hidden>No events yet.</div>
+  </div>
+
+  <nav><a href="/admin/pipeline">console</a><a href="/inbox">inbox</a><a href="/submit">submit</a></nav>
+
+  <script>
+    const $ = (id) => document.getElementById(id);
+
+    function fmtDetail(raw) {
+      if (!raw) return "";
+      let obj;
+      try { obj = JSON.parse(raw); } catch { return raw; }
+      return Object.entries(obj)
+        .filter(([, v]) => v !== null && v !== undefined && v !== "")
+        .map(([k, v]) => {
+          const s = String(v);
+          return k + "=" + (s.length > 110 ? s.slice(0, 110) + "…" : s);
+        })
+        .join(" · ");
+    }
+
+    function subjectHtml(e) {
+      const parts = [];
+      if (e.summary_id) {
+        const nnn = encodeURIComponent(e.summary_id);
+        parts.push(`<a href="/api/summaries/${nnn}" target="_blank"><b>${escapeHtml(e.summary_id)}</b></a>`);
+      }
+      if (e.link_id != null) parts.push(`link #${Number(e.link_id)}`);
+      return parts.join(" · ") || "–";
+    }
+
+    function evClass(name) {
+      if (name === "summary.created") return "ev good";
+      if (name === "pipeline.blocked") return "ev bad";
+      return "ev";
+    }
+
+    function escapeHtml(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
+
+    async function load() {
+      const p = new URLSearchParams();
+      p.set("limit", $("f-limit").value);
+      if ($("f-event").value) p.set("event", $("f-event").value);
+      const res = await fetch("/api/events?" + p, { credentials: "same-origin" });
+      if (!res.ok) { $("rows").innerHTML = `<tr><td colspan="5">failed to load (${res.status})</td></tr>`; return; }
+      const d = await res.json();
+      $("asof").textContent = d.count + " event" + (d.count === 1 ? "" : "s") + " shown.";
+      $("empty").hidden = d.count !== 0;
+      $("rows").innerHTML = "";
+      for (const e of d.events) {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+          <td class="ts">${(e.ts || "").slice(0, 19).replace("T", " ")}</td>
+          <td><span class="pill ${e.actor}">${e.actor}</span></td>
+          <td><span class="${evClass(e.event)}">${escapeHtml(e.event)}</span></td>
+          <td class="subj">${subjectHtml(e)}</td>
+          <td class="detail" title="${escapeHtml(e.detail || "")}">${escapeHtml(fmtDetail(e.detail))}</td>`;
+        $("rows").appendChild(tr);
+      }
+    }
+
+    $("f-event").onchange = load;
+    $("f-limit").onchange = load;
+    $("refresh").onclick = load;
+    load();
+    setInterval(load, 30_000);
+  </script>
+</body>
+</html>

--- a/platform/public/admin/logs/index.html
+++ b/platform/public/admin/logs/index.html
@@ -90,9 +90,9 @@
       const parts = [];
       if (e.summary_id) {
         const nnn = encodeURIComponent(e.summary_id);
-        parts.push(`<a href="/api/summaries/${nnn}" target="_blank"><b>${escapeHtml(e.summary_id)}</b></a>`);
+        parts.push(`NNN <a href="/api/summaries/${nnn}" target="_blank"><b>${escapeHtml(e.summary_id)}</b></a>`);
       }
-      if (e.link_id != null) parts.push(`link #${Number(e.link_id)}`);
+      if (e.link_id != null) parts.push(`L${Number(e.link_id)}`);
       return parts.join(" · ") || "–";
     }
 

--- a/platform/public/admin/pipeline/index.html
+++ b/platform/public/admin/pipeline/index.html
@@ -66,7 +66,7 @@
     <tbody id="rows"></tbody>
   </table></div>
 
-  <nav><a href="/submit">submit</a><a href="/inbox">inbox</a><a href="/api/summaries" target="_blank">summaries API</a></nav>
+  <nav><a href="/submit">submit</a><a href="/inbox">inbox</a><a href="/admin/logs">events log</a><a href="/api/summaries" target="_blank">summaries API</a></nav>
 
   <dialog id="dlg">
     <b>Start new cycle</b>

--- a/platform/public/inbox/index.html
+++ b/platform/public/inbox/index.html
@@ -86,7 +86,8 @@
         if (l.error) { const er = document.createElement("div"); er.className = "err"; er.textContent = l.error; li.appendChild(er); }
         const meta = document.createElement("div"); meta.className = "meta";
         const pill = document.createElement("span"); pill.className = "pill " + l.status; pill.textContent = l.status === "new" ? "generating" : l.status;
-        const t = document.createElement("span"); t.textContent = (l.summary_id ? "NNN " + l.summary_id + " · " : "") + (l.submitted_at || "").replace("T", " ").slice(0, 16);
+        const t = document.createElement("span"); t.textContent = (l.summary_id ? "NNN " + l.summary_id + " · " : "") + (l.submitted_at || "").replace("T", " ").slice(0, 16) + "  ·  L" + l.id;
+        t.title = "L" + l.id + " = link id used as subject in /admin/logs";
         meta.appendChild(pill); meta.appendChild(t);
         const act = document.createElement("span"); act.className = "act";
         if (l.status !== "dismissed") act.appendChild(actBtn(l.id, "dismissed", "dismiss"));

--- a/platform/public/inbox/index.html
+++ b/platform/public/inbox/index.html
@@ -130,7 +130,7 @@
         actor.appendChild(pill);
         const ev = document.createElement("td"); ev.className = "ev"; ev.textContent = e.event;
         const subj = document.createElement("td"); subj.className = "subj";
-        subj.textContent = [e.summary_id ? "NNN " + e.summary_id : "", e.link_id != null ? "link #" + e.link_id : ""].filter(Boolean).join(" · ") || "–";
+        subj.textContent = [e.summary_id ? "NNN " + e.summary_id : "", e.link_id != null ? "L" + e.link_id : ""].filter(Boolean).join(" · ") || "–";
         tr.appendChild(ts); tr.appendChild(actor); tr.appendChild(ev); tr.appendChild(subj);
         rows.appendChild(tr);
       }

--- a/platform/public/inbox/index.html
+++ b/platform/public/inbox/index.html
@@ -28,7 +28,18 @@
     .act button { font-size: 12px; border: 1px solid var(--line); background: #fff; border-radius: 4px; padding: 2px 10px; cursor: pointer; }
     #empty { color: var(--muted); font-size: 14px; padding: 28px 0; }
     nav { margin-top: 28px; font-size: 13.5px; }
-    nav a { color: var(--accent); }
+    nav a { color: var(--accent); margin-right: 14px; }
+    #events { margin-top: 30px; border-top: 1px solid var(--line); padding-top: 14px; }
+    #events h2 { font-size: 14px; margin: 0 0 8px; display: flex; align-items: baseline; gap: 10px; }
+    #events h2 a { font-size: 12.5px; font-weight: 400; color: var(--accent); }
+    #events table { border-collapse: collapse; width: 100%; font-size: 12.5px; }
+    #events td { padding: 3px 8px 3px 0; border-bottom: 1px dotted var(--line); vertical-align: top; }
+    #events td.ts { white-space: nowrap; color: var(--muted); font-variant-numeric: tabular-nums; }
+    #events td.ev { font-family: ui-monospace, monospace; font-size: 11.5px; white-space: nowrap; }
+    #events .pill { font-size: 10px; }
+    #events .pill.editor { background: #e8eef5; color: #33567a; }
+    #events .pill.pipeline { background: #fdf3e4; color: #8a5307; }
+    #events td.subj { white-space: nowrap; color: #444; }
   </style>
 </head>
 <body>
@@ -44,7 +55,13 @@
   </div>
   <ul id="list"></ul>
   <div id="empty" hidden>Nothing here yet.</div>
-  <nav><a href="/submit">→ submit a link</a></nav>
+
+  <section id="events" hidden>
+    <h2>Latest events <a href="/admin/logs">full audit log →</a></h2>
+    <table><tbody id="ev-rows"></tbody></table>
+  </section>
+
+  <nav><a href="/submit">→ submit a link</a><a href="/admin/pipeline">console</a><a href="/admin/logs">events log</a></nav>
 
   <script>
     let current = "";
@@ -91,8 +108,31 @@
           body: JSON.stringify({ status }),
         });
         load();
+        loadEvents();
       };
       return b;
+    }
+
+    async function loadEvents() {
+      const res = await fetch("/api/events?limit=15", { credentials: "same-origin" });
+      if (!res.ok) return;
+      const d = await res.json();
+      const panel = document.getElementById("events");
+      const rows = document.getElementById("ev-rows");
+      panel.hidden = d.count === 0;
+      rows.innerHTML = "";
+      for (const e of d.events) {
+        const tr = document.createElement("tr");
+        const ts = document.createElement("td"); ts.className = "ts"; ts.textContent = (e.ts || "").slice(5, 16).replace("T", " ");
+        const actor = document.createElement("td");
+        const pill = document.createElement("span"); pill.className = "pill " + e.actor; pill.textContent = e.actor;
+        actor.appendChild(pill);
+        const ev = document.createElement("td"); ev.className = "ev"; ev.textContent = e.event;
+        const subj = document.createElement("td"); subj.className = "subj";
+        subj.textContent = [e.summary_id ? "NNN " + e.summary_id : "", e.link_id != null ? "link #" + e.link_id : ""].filter(Boolean).join(" · ") || "–";
+        tr.appendChild(ts); tr.appendChild(actor); tr.appendChild(ev); tr.appendChild(subj);
+        rows.appendChild(tr);
+      }
     }
 
     document.getElementById("filters").addEventListener("click", (e) => {
@@ -102,6 +142,8 @@
       load();
     });
     load();
+    loadEvents();
+    setInterval(loadEvents, 30_000);
   </script>
 </body>
 </html>

--- a/platform/worker/src/index.ts
+++ b/platform/worker/src/index.ts
@@ -9,6 +9,7 @@
 // infra failures rethrow so the alarm's built-in retry/backoff handles them.
 
 import { DurableObject } from "cloudflare:workers";
+import { logEvent } from "../../functions/_lib/events";
 import { allocateId, getCycle, writeSummary } from "../../functions/_lib/summaries";
 import { logRun, summarizeUrl, tokensFromUsage, type LinkRow, type SummarizeMeta, type SummarizeResult } from "./core";
 
@@ -76,6 +77,13 @@ export class SummarizerDO extends DurableObject<PipelineEnv> {
     await this.env.DB.prepare("UPDATE links SET status = 'blocked', error = ? WHERE id = ? AND status = 'queued'")
       .bind(reason.slice(0, 500), linkId)
       .run();
+    const t = tokensFromUsage(meta?.usage);
+    await logEvent(this.env.DB, {
+      actor: "pipeline",
+      event: "pipeline.blocked",
+      linkId,
+      detail: { reason: reason.slice(0, 500), model: meta?.model, fetch_ms: meta?.fetchMs, ai_ms: meta?.aiMs, tokens_in: t.tokensIn, tokens_out: t.tokensOut },
+    });
   }
 
   private async recordRun(linkId: number, meta?: Partial<SummarizeMeta>): Promise<void> {
@@ -117,6 +125,14 @@ export class SummarizerDO extends DurableObject<PipelineEnv> {
     )
       .bind(id, link.id)
       .run();
+    const t = tokensFromUsage(out.meta.usage);
+    await logEvent(this.env.DB, {
+      actor: "pipeline",
+      event: "summary.created",
+      linkId: link.id,
+      summaryId: id,
+      detail: { model: out.meta.model, fetch_ms: out.meta.fetchMs, ai_ms: out.meta.aiMs, tokens_in: t.tokensIn, tokens_out: t.tokensOut },
+    });
   }
 }
 


### PR DESCRIPTION
Closes #172 — implements it within its scope declaration: **summarization events only** — link lifecycle (submitted / dismissed / reopened), pipeline runs (summary.created / pipeline.blocked with metrics), summary flag flips (dismissed / restored), cycle rollovers. Journal/publish events (rebuilds, journal_date stamping, deploys) are deferred to the publish phase (#163).

## Design

- **`migrations/0008_events.sql`** — append-only `events` table: `id, ts (UTC ms default), actor ('editor'|'pipeline'|'system'), event, link_id, summary_id, detail (JSON)`; indexes on `(ts DESC)` and `(summary_id)`. Events deliberately survive link-row deletion — they ARE the audit trail.
- **`functions/_lib/events.ts`** — single `logEvent(db, {...})` helper, fire-and-forget (swallows every error; the trail must never break the operation it records). Imported by both Pages Functions and the pipeline DO (same cross-boundary pattern as `summaries.ts`).
- **Emitters** — actor `editor` for any authorized human/bearer (identity kept in `detail.by`), `pipeline` for the DO:
  - links POST → `link.submitted`
  - links PATCH dismiss → `link.dismissed` + `summary.dismissed` (only when the workdesk flag actually flips)
  - links PATCH re-open → `link.reopened` + `summary.restored` on flag flip; `link.reopened` (`requeued: true`) when it re-enqueues instead
  - cycle POST → `cycle.rolled` (`{date, next_id}`)
  - SummarizerDO → `summary.created` (`model, fetch_ms, ai_ms, tokens_in/out`) / `pipeline.blocked` (`reason` + metrics) — emitted inside `block()`, so no-cycle / fetch-fail / invalid-output / store-reject all land in the trail
- **`GET /api/events?limit=&event=&summary_id=&link_id=`** — bearer/Access auth, default 50, clamped to 200, newest-first.
- **UI** — `/admin/logs` (Access-protected): full audit table with actor pills, event filter, limit selector, 30 s auto-refresh, subject links to `/api/summaries/NNN`; inbox gets a compact latest-15 events panel linking through to `/admin/logs`; nav wired between submit/inbox/console/logs.

## Verification (production E2E)

- `npm run check` (tsc) and `npm test` (vitest 9/9) pass; migration applied `--local` + `--remote`; Pages + worker deployed.
- Submitted `https://example.com/events-test` via bearer → `link.submitted` recorded instantly; ~20 s later the DO run recorded `pipeline.blocked` (`reason: "BLOCKED: fetch returned HTTP 404"`).
- Dismiss → `link.dismissed`; re-open → `link.reopened` (`requeued: true`); `?link_id=9` returned the full 5-event history in order.
- `?event=pipeline.blocked` filter, `limit` clamping, and unauthenticated `401` verified.
- Deleted the test link row via `wrangler d1 execute` — all its events remain queryable (append-only semantics confirmed).
- `/admin/logs` returns `302` to `gentle-hill-7034.cloudflareaccess.com` (Access wall covers the new page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
