### PR TITLE
Platform: summary detail page — actions, per-run log, re-summarize (#173)

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -25,10 +25,16 @@ functions/            Pages Functions = the HTTP API
   api/cycle.ts        GET registry state, POST rollover (seed counter per #165 rule)
   api/pipeline.ts     joined operational view for the console
   api/events.ts       GET audit trail: ?limit= (≤200) &event= &summary_id= &link_id=
+  admin/summaries/    GET /admin/summaries/:id — server-rendered summary detail
+                      page (#173): content, link + run metrics, actions
+                      (dismiss / re-open / re-summarize), per-run event log
+  _lib/summary_page.ts  pure HTML renderer for the detail page (unit-tested)
 public/               static, Access-protected where sensitive
   submit/ inbox/      link intake UI + bookmarklet (+ latest-events panel)
   admin/pipeline/     operations console: states, errors, metrics, retry, rollover
   admin/logs/         events log: full audit trail, filterable, auto-refresh
+                      Lists are read-mostly (#173): NNN links navigate to the
+                      detail page; only retry-on-blocked stays on the console
 worker/               companion Worker "gen-ai-journal-pipeline"
   src/index.ts        SummarizerDO: alarm-driven queue (debounce 20s, serial,
                       stale-claim recovery, infra-retry via alarm backoff)
@@ -66,6 +72,9 @@ wrangler tail gen-ai-journal-pipeline                     # live structured run 
 - Dismiss is a **reversible flag**: the summary row stays, marked `dismissed`
   (excluded from `status=workdesk` consumers; published rows never touched).
   Re-open flips it back instantly — no regeneration, no token spend.
+- **Re-summarize** (detail page, confirm-gated): PATCH the summarized link
+  back to `new` while its summary is NOT dismissed → the pipeline re-runs and
+  overwrites the content under the same NNN (token spend, `updated_at` moves).
 - Blocked = fail-closed with a reason on the link; PDFs & bot-blocked pages
   are regenerated locally and pushed (#168, permanent fallback path).
 - Every summarization-lifecycle interaction lands in the append-only `events`

--- a/platform/functions/_lib/summary_page.ts
+++ b/platform/functions/_lib/summary_page.ts
@@ -1,0 +1,322 @@
+// Summary detail page renderer (#173) — pure HTML-building for
+// /admin/summaries/<NNN>. Kept out of the route file so vitest can pin the
+// invariants (dismissed hides body, user content is escaped) without a D1.
+//
+// Everything that originates from the DB or the LLM goes through esc();
+// the only unescaped interpolations are safeJson() (for the client script)
+// and fixed literals.
+
+export interface SummaryRow {
+  id: string;
+  journal_date: string | null;
+  url: string | null;
+  content: string;
+  status: string; // workdesk | published | blocked | dismissed
+  pushed_at: string | null;
+  updated_at: string | null;
+}
+
+export interface LinkRow {
+  id: number;
+  url: string;
+  note: string | null;
+  status: string; // new | queued | summarized | blocked | dismissed
+  error: string | null;
+  submitted_at: string | null;
+  processed_at: string | null;
+  fetch_ms: number | null;
+  ai_ms: number | null;
+  tokens_in: number | null;
+  tokens_out: number | null;
+}
+
+export function esc(v: unknown): string {
+  return String(v ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** JSON for inline <script> consts — <-escaped so "</script>" can't break out. */
+function safeJson(v: unknown): string {
+  return JSON.stringify(v).replace(/</g, "\\u003c");
+}
+
+function isHttpUrl(u: unknown): boolean {
+  return typeof u === "string" && /^https?:\/\//i.test(u);
+}
+
+/** Clickable only when it looks like http(s); otherwise plain escaped text. */
+function urlHtml(u: unknown): string {
+  if (!u) return "–";
+  return isHttpUrl(u)
+    ? `<a href="${esc(u)}" target="_blank" rel="noreferrer">${esc(u)}</a>`
+    : esc(u);
+}
+
+function fmtMs(ms: number | null | undefined): string {
+  if (ms == null) return "–";
+  return ms >= 1000 ? (ms / 1000).toFixed(1) + "s" : ms + "ms";
+}
+
+function fmtTs(ts: string | null | undefined): string {
+  return ts ? esc(ts.slice(0, 19).replace("T", " ")) : "–";
+}
+
+const SCORE_KEYS = ["signal", "depth", "uniqueness", "practical", "antiHype", "mainJournal", "annexPotential", "overall"] as const;
+
+const STYLE = `
+    :root { --accent: #d96b0b; --line: #ddd8ce; --muted: #6a6f7a; --ok: #22633c; --bad: #a33326; }
+    body { font-family: system-ui, sans-serif; max-width: 860px; margin: 5vh auto; padding: 0 20px 60px; color: #21252d; line-height: 1.6; }
+    h1 { font-size: 22px; margin: 0 0 4px; display: flex; align-items: center; gap: 10px; }
+    p.sub { color: var(--muted); margin: 0 0 20px; font-size: 13.5px; }
+    section { border: 1px solid var(--line); border-radius: 6px; padding: 16px 20px; margin-bottom: 16px; background: #fff; }
+    section h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin: 0 0 10px; }
+    .title { font-size: 18px; font-weight: 700; margin: 0 0 2px; }
+    .orig { color: var(--muted); font-size: 13px; margin: 0 0 10px; }
+    .chips { margin: 0 0 12px; }
+    .chip { display: inline-block; font-size: 11.5px; padding: 1px 10px; border-radius: 20px; background: #f2efe9; margin: 0 5px 5px 0; }
+    .chip.kind { background: #e8eef5; color: #33567a; }
+    .lead { border-left: 3px solid var(--accent); padding: 2px 12px; margin: 0 0 14px; font-weight: 600; }
+    .body p { margin: 0 0 10px; font-size: 14.5px; }
+    .pill { font-size: 11px; padding: 1px 9px; border-radius: 20px; background: #eee; white-space: nowrap; font-weight: 400; }
+    .pill.workdesk, .pill.summarized { background: #e8eef5; color: #33567a; }
+    .pill.published, .pill.new { background: #e7f2ea; color: var(--ok); }
+    .pill.queued { background: #fdf3e4; color: #8a5307; }
+    .pill.blocked { background: #fbe9e7; color: var(--bad); }
+    .pill.dismissed { background: #f0f0ee; color: #888; }
+    .notice { border: 1px dashed var(--line); border-radius: 6px; background: #faf9f6; color: var(--muted); padding: 14px 18px; font-size: 14px; margin-bottom: 16px; }
+    pre.raw { background: #faf9f6; border: 1px solid var(--line); border-radius: 6px; padding: 12px 14px; font-size: 12.5px; overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
+    table { border-collapse: collapse; width: 100%; font-size: 13px; }
+    th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); padding: 5px 10px 5px 0; border-bottom: 1px solid var(--line); white-space: nowrap; }
+    td { padding: 5px 10px 5px 0; border-bottom: 1px solid var(--line); vertical-align: top; }
+    td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
+    .kv td:first-child { color: var(--muted); white-space: nowrap; width: 120px; }
+    .kv td { word-break: break-all; }
+    .tbl-wrap { overflow-x: auto; }
+    .err { color: var(--bad); }
+    .actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    .actions button { font-size: 13px; border: 1px solid var(--line); background: #fff; border-radius: 5px; padding: 5px 14px; cursor: pointer; }
+    .actions button.warn { border-color: var(--accent); color: var(--accent); font-weight: 600; }
+    .actions .hint { font-size: 12px; color: var(--muted); align-self: center; }
+    #log td.ts { white-space: nowrap; color: var(--muted); font-variant-numeric: tabular-nums; }
+    #log td.ev { font-family: ui-monospace, monospace; font-size: 11.5px; white-space: nowrap; }
+    #log .pill.editor { background: #e8eef5; color: #33567a; }
+    #log .pill.pipeline { background: #fdf3e4; color: #8a5307; }
+    #log .pill.system { background: #f0f0ee; color: #888; }
+    #log td.detail { color: #444; font-size: 12.5px; word-break: break-word; }
+    nav { margin-top: 22px; font-size: 13.5px; }
+    nav a { color: var(--accent); margin-right: 16px; }
+`;
+
+function shell(title: string, body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>${esc(title)}</title>
+  <style>${STYLE}</style>
+</head>
+<body>
+${body}
+</body>
+</html>
+`;
+}
+
+export function renderErrorPage(id: string, message: string): string {
+  return shell(
+    `Summary ${id} — gen-ai-journal`,
+    `  <h1>Summary ${esc(id)}</h1>
+  <div class="notice">${esc(message)}</div>
+  <nav><a href="/admin/pipeline">console</a><a href="/inbox">inbox</a><a href="/admin/logs">events log</a></nav>`,
+  );
+}
+
+/** Rich render of summary-v1 JSON; falls back to <pre> for stubs/unparseable. */
+function contentHtml(s: SummaryRow): string {
+  if (s.status === "dismissed") {
+    return `<div class="notice">Content hidden while dismissed — re-open the link below to restore it. The row (and its content) still exists.</div>`;
+  }
+  const raw = s.content ?? "";
+  if (raw.trimStart().startsWith("BLOCKED")) {
+    return `<section><h2>Blocked stub</h2><pre class="raw">${esc(raw)}</pre></section>`;
+  }
+  let c: Record<string, unknown> | null = null;
+  try {
+    c = (JSON.parse(raw) as { content?: Record<string, unknown> })?.content ?? null;
+  } catch {
+    /* fall through to raw */
+  }
+  if (!c) {
+    return `<section><h2>Stored content (unparseable as summary-v1)</h2><pre class="raw">${esc(raw)}</pre></section>`;
+  }
+
+  const chips: string[] = [];
+  if (c.language) chips.push(`<span class="chip kind">lang: ${esc(c.language)}</span>`);
+  if (c.contentType) chips.push(`<span class="chip kind">${esc(c.contentType)}</span>`);
+  for (const t of Array.isArray(c.topics) ? c.topics : []) chips.push(`<span class="chip">${esc(t)}</span>`);
+
+  const paragraphs = String(c.summaryBody ?? "")
+    .split(/\n{2,}/)
+    .filter((p) => p.trim())
+    .map((p) => `<p>${esc(p.trim()).replace(/\n/g, "<br>")}</p>`)
+    .join("\n      ");
+
+  const scores = (c.scores ?? {}) as Record<string, unknown>;
+  const scoreTable = `<div class="tbl-wrap"><table>
+      <thead><tr>${SCORE_KEYS.map((k) => `<th>${k}</th>`).join("")}</tr></thead>
+      <tbody><tr>${SCORE_KEYS.map((k) => `<td class="num">${esc(scores[k] ?? "–")}</td>`).join("")}</tr></tbody>
+    </table></div>`;
+
+  return `<section>
+    <div class="title">${esc(c.title ?? "(untitled)")}</div>
+    ${c.originalTitle ? `<div class="orig">原題: ${esc(c.originalTitle)}</div>` : ""}
+    <div class="chips">${chips.join("")}</div>
+    ${c.oneSentenceSummary ? `<div class="lead">${esc(c.oneSentenceSummary)}</div>` : ""}
+    <div class="body">
+      ${paragraphs || "<p>(empty summaryBody)</p>"}
+    </div>
+    <h2 style="margin-top:14px">Scores</h2>
+    ${scoreTable}
+  </section>`;
+}
+
+function actionButtons(link: LinkRow): string {
+  const btn = (label: string, status: string, confirmMsg: string, warn = false) =>
+    `<button data-status="${esc(status)}" data-confirm="${esc(confirmMsg)}"${warn ? ' class="warn"' : ""}>${esc(label)}</button>`;
+
+  const btns: string[] = [];
+  let hint = "";
+  if (link.status === "dismissed") {
+    btns.push(btn("re-open", "new", ""));
+    hint = "re-open restores a dismissed summary instantly (no regeneration, no token spend)";
+  } else {
+    if (link.status === "summarized") {
+      btns.push(
+        btn(
+          "re-summarize",
+          "new",
+          "Re-run the pipeline for this link?\n\nThis OVERWRITES the content under the same NNN and spends tokens.",
+          true,
+        ),
+      );
+    }
+    if (link.status === "blocked") {
+      btns.push(btn("retry", "new", "Retry summarization for this link? It spends tokens.", true));
+    }
+    btns.push(btn("dismiss", "dismissed", ""));
+    if (link.status === "summarized") hint = "dismiss is a reversible flag; re-summarize reuses this NNN";
+  }
+  return `<div class="actions">${btns.join("")}${hint ? `<span class="hint">${esc(hint)}</span>` : ""}</div>`;
+}
+
+function linkSectionHtml(link: LinkRow | null): string {
+  if (!link) {
+    return `<section><h2>Link</h2>
+    <div class="notice" style="border:none;padding:0;margin:0">No link row references this NNN (deleted, or pushed via the local fallback). Actions unavailable.</div>
+  </section>`;
+  }
+  const label = link.status === "new" ? "generating" : link.status;
+  return `<section><h2>Link</h2>
+    <table class="kv"><tbody>
+      <tr><td>url</td><td>${urlHtml(link.url)}</td></tr>
+      <tr><td>link</td><td>L${Number(link.id)} <span class="pill ${esc(link.status)}">${esc(label)}</span></td></tr>
+      ${link.note ? `<tr><td>note</td><td>${esc(link.note)}</td></tr>` : ""}
+      ${link.error ? `<tr><td>error</td><td class="err">${esc(link.error)}</td></tr>` : ""}
+      <tr><td>submitted</td><td>${fmtTs(link.submitted_at)}</td></tr>
+      <tr><td>last run</td><td>${fmtTs(link.processed_at)} · fetch ${fmtMs(link.fetch_ms)} + ai ${fmtMs(link.ai_ms)} · tokens ${link.tokens_in != null ? `${esc(link.tokens_in)}/${esc(link.tokens_out ?? "–")}` : "–"}</td></tr>
+    </tbody></table>
+    ${actionButtons(link)}
+  </section>`;
+}
+
+// Client script: fixed code — the only dynamic value is the PAGE const,
+// injected via safeJson(). Log rows are built with textContent (no innerHTML).
+const CLIENT_SCRIPT = `
+    async function act(status, confirmMsg) {
+      if (confirmMsg && !window.confirm(confirmMsg)) return;
+      const res = await fetch("/api/links/" + PAGE.linkId, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) { alert("action failed (" + res.status + ")"); return; }
+      location.reload();
+    }
+    document.querySelectorAll(".actions button").forEach((b) => {
+      b.onclick = () => { b.disabled = true; act(b.dataset.status, b.dataset.confirm).finally(() => { b.disabled = false; }); };
+    });
+
+    function fmtDetail(raw) {
+      if (!raw) return "";
+      let obj;
+      try { obj = JSON.parse(raw); } catch { return raw; }
+      return Object.entries(obj)
+        .filter(([, v]) => v !== null && v !== undefined && v !== "")
+        .map(([k, v]) => { const s = String(v); return k + "=" + (s.length > 110 ? s.slice(0, 110) + "…" : s); })
+        .join(" · ");
+    }
+
+    async function loadLog() {
+      const qs = ["summary_id=" + encodeURIComponent(PAGE.summaryId)];
+      if (PAGE.linkId != null) qs.push("link_id=" + PAGE.linkId);
+      const lists = await Promise.all(qs.map(async (q) => {
+        const res = await fetch("/api/events?limit=200&" + q, { credentials: "same-origin" });
+        return res.ok ? (await res.json()).events : [];
+      }));
+      const seen = new Set();
+      const events = [];
+      for (const e of lists.flat()) {
+        if (seen.has(e.id)) continue;
+        seen.add(e.id);
+        events.push(e);
+      }
+      events.sort((a, b) => b.id - a.id); // newest first
+      const rows = document.getElementById("log-rows");
+      rows.innerHTML = "";
+      document.getElementById("log-empty").hidden = events.length !== 0;
+      for (const e of events) {
+        const tr = document.createElement("tr");
+        const ts = document.createElement("td"); ts.className = "ts"; ts.textContent = (e.ts || "").slice(0, 19).replace("T", " ");
+        const actor = document.createElement("td");
+        const pill = document.createElement("span"); pill.className = "pill " + e.actor; pill.textContent = e.actor;
+        actor.appendChild(pill);
+        const ev = document.createElement("td"); ev.className = "ev"; ev.textContent = e.event;
+        const detail = document.createElement("td"); detail.className = "detail"; detail.textContent = fmtDetail(e.detail);
+        tr.appendChild(ts); tr.appendChild(actor); tr.appendChild(ev); tr.appendChild(detail);
+        rows.appendChild(tr);
+      }
+    }
+    loadLog();
+`;
+
+export function renderSummaryPage(summary: SummaryRow, link: LinkRow | null): string {
+  const page = { summaryId: summary.id, linkId: link ? link.id : null };
+  const body = `  <h1>Summary ${esc(summary.id)} <span class="pill ${esc(summary.status)}">${esc(summary.status)}</span></h1>
+  <p class="sub">${summary.journal_date ? `journal ${esc(summary.journal_date)}` : "workdesk (current cycle)"} · pushed ${fmtTs(summary.pushed_at)} · updated ${fmtTs(summary.updated_at)} · <a href="/api/summaries/${esc(summary.id)}" target="_blank" style="color:var(--accent)">raw JSON</a></p>
+
+${contentHtml(summary)}
+
+${linkSectionHtml(link)}
+
+  <section id="log"><h2>Summarization log</h2>
+    <div class="tbl-wrap"><table>
+      <thead><tr><th>time (UTC)</th><th>actor</th><th>event</th><th>detail</th></tr></thead>
+      <tbody id="log-rows"></tbody>
+    </table></div>
+    <div id="log-empty" hidden style="color:var(--muted);font-size:13px;padding:10px 0 0">No events recorded for this NNN.</div>
+  </section>
+
+  <nav><a href="/admin/pipeline">console</a><a href="/inbox">inbox</a><a href="/admin/logs">events log</a><a href="/submit">submit</a></nav>
+
+  <script>
+    const PAGE = ${safeJson(page)};
+${CLIENT_SCRIPT}  </script>`;
+  return shell(`Summary ${summary.id} — gen-ai-journal`, body);
+}

--- a/platform/functions/admin/summaries/[id].ts
+++ b/platform/functions/admin/summaries/[id].ts
@@ -1,0 +1,39 @@
+// GET /admin/summaries/:id (#173) — server-rendered summary detail page.
+// The primary wall is Cloudflare Access on /admin/* (edge 302 before this
+// runs); authorize() here is defense-in-depth only. Raw JSON stays at
+// /api/summaries/:id — this page is the human view: content, link + run
+// metrics, actions (dismiss / re-open / re-summarize), per-run event log.
+
+import { authorize, type Env } from "../../_lib/auth";
+import { renderErrorPage, renderSummaryPage, type LinkRow, type SummaryRow } from "../../_lib/summary_page";
+
+function html(markup: string, status = 200): Response {
+  return new Response(markup, { status, headers: { "content-type": "text/html; charset=utf-8" } });
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ request, env, params }) => {
+  const who = await authorize(request, env);
+  if (!who) return new Response("unauthorized", { status: 401 });
+
+  const id = String(params.id);
+  if (!/^\d{3,}$/.test(id)) return html(renderErrorPage(id, "Invalid id — expected a zero-padded NNN like 003."), 400);
+
+  // The admin detail covers the current cycle: the workdesk row only.
+  // Published rows remain reachable via /api/summaries/:id?journal_date=….
+  const summary = await env.DB.prepare(
+    "SELECT id, journal_date, url, content, status, pushed_at, updated_at FROM summaries WHERE id = ? AND journal_date IS NULL",
+  )
+    .bind(id)
+    .first<SummaryRow>();
+  if (!summary) {
+    return html(renderErrorPage(id, "No workdesk summary with this NNN. Published rows: /api/summaries/" + id + "?journal_date=YYYY-MM-DD."), 404);
+  }
+
+  const link = await env.DB.prepare(
+    "SELECT id, url, note, status, error, submitted_at, processed_at, fetch_ms, ai_ms, tokens_in, tokens_out FROM links WHERE summary_id = ? ORDER BY id DESC LIMIT 1",
+  )
+    .bind(id)
+    .first<LinkRow>();
+
+  return html(renderSummaryPage(summary, link ?? null));
+};

--- a/platform/public/admin/logs/index.html
+++ b/platform/public/admin/logs/index.html
@@ -90,7 +90,7 @@
       const parts = [];
       if (e.summary_id) {
         const nnn = encodeURIComponent(e.summary_id);
-        parts.push(`NNN <a href="/api/summaries/${nnn}" target="_blank"><b>${escapeHtml(e.summary_id)}</b></a>`);
+        parts.push(`NNN <a href="/admin/summaries/${nnn}" target="_blank"><b>${escapeHtml(e.summary_id)}</b></a>`);
       }
       if (e.link_id != null) parts.push(`L${Number(e.link_id)}`);
       return parts.join(" · ") || "–";

--- a/platform/public/admin/pipeline/index.html
+++ b/platform/public/admin/pipeline/index.html
@@ -107,12 +107,12 @@
       $("rows").innerHTML = rows.length ? "" : `<tr><td colspan="7" style="color:var(--muted)">nothing here</td></tr>`;
       for (const l of rows) {
         const tr = document.createElement("tr");
+        // Read-mostly list (#173): dismiss/re-open/re-summarize live on the
+        // summary detail page; only retry-on-blocked stays here.
         const acts = [];
         if (l.status === "blocked") acts.push(`<button data-a="retry" data-id="${l.id}">retry</button>`);
-        if (l.status !== "dismissed") acts.push(`<button data-a="dismiss" data-id="${l.id}" data-st="${l.status}" data-nnn="${l.summary_id ?? ""}">dismiss</button>`);
-        else acts.push(`<button data-a="retry" data-id="${l.id}">re-open</button>`);
         tr.innerHTML = `
-          <td class="num">${l.summary_id ? `<a href="/api/summaries/${l.summary_id}" target="_blank"><b>${l.summary_id}</b></a>` : "–"}</td>
+          <td class="num">${l.summary_id ? `<a href="/admin/summaries/${encodeURIComponent(l.summary_id)}" target="_blank"><b>${l.summary_id}</b></a>` : "–"}</td>
           <td><span class="pill ${l.status}">${l.status === "new" ? "generating" : l.status}</span></td>
           <td><div class="u"><a href="${l.url}" target="_blank" rel="noreferrer">${l.url}</a></div>
               ${l.note ? `<div style="font-size:12px;color:var(--muted)">${escapeHtml(l.note)}</div>` : ""}
@@ -127,15 +127,13 @@
     function escapeHtml(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
 
     document.body.addEventListener("click", async (e) => {
-      const a = e.target.dataset?.a;
-      if (!a) return;
-      const status = a === "retry" ? "new" : "dismissed";
+      if (e.target.dataset?.a !== "retry") return;
       e.target.disabled = true;
       await fetch(`/api/links/${e.target.dataset.id}`, {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         credentials: "same-origin",
-        body: JSON.stringify({ status }),
+        body: JSON.stringify({ status: "new" }),
       });
       load();
     });

--- a/platform/public/admin/pipeline/index.html
+++ b/platform/public/admin/pipeline/index.html
@@ -129,13 +129,20 @@
     document.body.addEventListener("click", async (e) => {
       if (e.target.dataset?.a !== "retry") return;
       e.target.disabled = true;
-      await fetch(`/api/links/${e.target.dataset.id}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        credentials: "same-origin",
-        body: JSON.stringify({ status: "new" }),
-      });
-      load();
+      try {
+        const res = await fetch(`/api/links/${e.target.dataset.id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({ status: "new" }),
+        });
+        if (!res.ok) { alert("retry failed (" + res.status + ")"); return; }
+        load();
+      } catch (err) {
+        alert("retry failed: " + err);
+      } finally {
+        e.target.disabled = false;
+      }
     });
 
     $("filters").addEventListener("click", (e) => {

--- a/platform/public/inbox/index.html
+++ b/platform/public/inbox/index.html
@@ -17,6 +17,7 @@
     li { border: 1px solid var(--line); border-radius: 6px; padding: 12px 16px; margin-bottom: 10px; }
     li .u a { color: #1f4e79; word-break: break-all; text-decoration-thickness: 1px; }
     li .meta { font-size: 12.5px; color: var(--muted); margin-top: 4px; display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+    li .meta a.nnn { color: var(--accent); font-weight: 600; }
     .pill { font-size: 11px; padding: 1px 9px; border-radius: 20px; background: #eee; }
     .pill.new { background: #e7f2ea; color: #22633c; }
     .pill.consumed { background: #e8eef5; color: #33567a; }
@@ -24,8 +25,6 @@
     .pill.blocked { background: #fbe9e7; color: #a33326; }
     .err { color: #a33326; font-size: 12px; margin-top: 2px; word-break: break-all; }
     .note { font-size: 13px; color: #444; margin-top: 4px; }
-    .act { margin-left: auto; }
-    .act button { font-size: 12px; border: 1px solid var(--line); background: #fff; border-radius: 4px; padding: 2px 10px; cursor: pointer; }
     #empty { color: var(--muted); font-size: 14px; padding: 28px 0; }
     nav { margin-top: 28px; font-size: 13.5px; }
     nav a { color: var(--accent); margin-right: 14px; }
@@ -40,6 +39,7 @@
     #events .pill.editor { background: #e8eef5; color: #33567a; }
     #events .pill.pipeline { background: #fdf3e4; color: #8a5307; }
     #events td.subj { white-space: nowrap; color: #444; }
+    #events td.subj a { color: #1f4e79; }
   </style>
 </head>
 <body>
@@ -86,32 +86,22 @@
         if (l.error) { const er = document.createElement("div"); er.className = "err"; er.textContent = l.error; li.appendChild(er); }
         const meta = document.createElement("div"); meta.className = "meta";
         const pill = document.createElement("span"); pill.className = "pill " + l.status; pill.textContent = l.status === "new" ? "generating" : l.status;
-        const t = document.createElement("span"); t.textContent = (l.summary_id ? "NNN " + l.summary_id + " · " : "") + (l.submitted_at || "").replace("T", " ").slice(0, 16) + "  ·  L" + l.id;
+        meta.appendChild(pill);
+        if (l.summary_id) {
+          // Read-mostly list (#173): actions live on the summary detail page.
+          const nnn = document.createElement("a");
+          nnn.className = "nnn";
+          nnn.href = "/admin/summaries/" + encodeURIComponent(l.summary_id);
+          nnn.textContent = "NNN " + l.summary_id;
+          nnn.title = "summary detail: content, actions, run log";
+          meta.appendChild(nnn);
+        }
+        const t = document.createElement("span"); t.textContent = (l.submitted_at || "").replace("T", " ").slice(0, 16) + "  ·  L" + l.id;
         t.title = "L" + l.id + " = link id used as subject in /admin/logs";
-        meta.appendChild(pill); meta.appendChild(t);
-        const act = document.createElement("span"); act.className = "act";
-        if (l.status !== "dismissed") act.appendChild(actBtn(l.id, "dismissed", "dismiss"));
-        else act.appendChild(actBtn(l.id, "new", "re-open"));
-        meta.appendChild(act);
+        meta.appendChild(t);
         li.appendChild(meta);
         list.appendChild(li);
       }
-    }
-
-    function actBtn(id, status, label) {
-      const b = document.createElement("button");
-      b.textContent = label;
-      b.onclick = async () => {
-        await fetch("/api/links/" + id, {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          credentials: "same-origin",
-          body: JSON.stringify({ status }),
-        });
-        load();
-        loadEvents();
-      };
-      return b;
     }
 
     async function loadEvents() {
@@ -130,7 +120,15 @@
         actor.appendChild(pill);
         const ev = document.createElement("td"); ev.className = "ev"; ev.textContent = e.event;
         const subj = document.createElement("td"); subj.className = "subj";
-        subj.textContent = [e.summary_id ? "NNN " + e.summary_id : "", e.link_id != null ? "L" + e.link_id : ""].filter(Boolean).join(" · ") || "–";
+        if (e.summary_id) {
+          const a = document.createElement("a");
+          a.href = "/admin/summaries/" + encodeURIComponent(e.summary_id);
+          a.textContent = "NNN " + e.summary_id;
+          subj.appendChild(a);
+          if (e.link_id != null) subj.appendChild(document.createTextNode(" · L" + Number(e.link_id)));
+        } else {
+          subj.textContent = e.link_id != null ? "L" + Number(e.link_id) : "–";
+        }
         tr.appendChild(ts); tr.appendChild(actor); tr.appendChild(ev); tr.appendChild(subj);
         rows.appendChild(tr);
       }

--- a/platform/tests/unit.test.ts
+++ b/platform/tests/unit.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import { sanitizeUrl, validateUrl } from "../functions/_lib/util";
 import { blockedStubUrl, displayTitle, inspectSummary, isBlockedStub } from "../functions/_lib/summaries";
+import { renderSummaryPage, type LinkRow, type SummaryRow } from "../functions/_lib/summary_page";
 import { tokensFromUsage } from "../worker/src/core";
 
 describe("sanitizeUrl (mirrors scripts/check_link.py)", () => {
@@ -54,6 +55,74 @@ describe("summary classification", () => {
     expect(displayTitle(VALID)).toBe("T");
     expect(displayTitle("BLOCKED: reason here")).toContain("BLOCKED");
     expect(displayTitle("garbage")).toBe("(unparseable)");
+  });
+});
+
+describe("renderSummaryPage (#173 detail page)", () => {
+  const mkSummary = (over: Partial<SummaryRow> = {}): SummaryRow => ({
+    id: "042",
+    journal_date: null,
+    url: "https://e.com/a",
+    content: JSON.stringify({
+      metadata: { version: "1.0", generatedAt: "t", generatedBy: "m" },
+      content: {
+        title: "見出し <script>alert(1)</script>",
+        originalTitle: "Original & <Title>",
+        url: "https://e.com/a",
+        language: "en",
+        contentType: "news",
+        oneSentenceSummary: "一文要約。",
+        summaryBody: "SECRET-BODY-MARKER 段落1。\n\n段落2。",
+        topics: ["agents", "<b>xss</b>"],
+        scores: { signal: 4, depth: 3, uniqueness: 2, practical: 4, antiHype: 5, mainJournal: 3, annexPotential: 4, overall: 4 },
+      },
+    }),
+    status: "workdesk",
+    pushed_at: "2026-07-06T00:00:00Z",
+    updated_at: "2026-07-06T00:00:00Z",
+    ...over,
+  });
+  const link: LinkRow = {
+    id: 7,
+    url: "https://e.com/a",
+    note: null,
+    status: "summarized",
+    error: null,
+    submitted_at: "2026-07-06T00:00:00Z",
+    processed_at: "2026-07-06T00:01:00Z",
+    fetch_ms: 500,
+    ai_ms: 12000,
+    tokens_in: 9000,
+    tokens_out: 800,
+  };
+
+  it("renders content with all user text HTML-escaped", () => {
+    const html = renderSummaryPage(mkSummary(), link);
+    expect(html).toContain("SECRET-BODY-MARKER");
+    expect(html).toContain("原題: Original &amp; &lt;Title&gt;");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;b&gt;xss&lt;/b&gt;");
+    expect(html).toContain("re-summarize"); // summarized link → re-summarize action
+    expect(html).toContain("L7");
+  });
+
+  it("dismissed summaries hide the body but keep metadata + re-open", () => {
+    const html = renderSummaryPage(mkSummary({ status: "dismissed" }), { ...link, status: "dismissed" });
+    expect(html).not.toContain("SECRET-BODY-MARKER");
+    expect(html).toContain("hidden while dismissed");
+    expect(html).toContain("re-open");
+    expect(html).not.toContain("re-summarize");
+    expect(html).toContain("Summary 042");
+  });
+
+  it("blocked stubs render as escaped raw text; no link row → no actions", () => {
+    const html = renderSummaryPage(
+      mkSummary({ status: "blocked", content: "BLOCKED: paywall <hit>\n\n- URL: https://e.com/a\n" }),
+      null,
+    );
+    expect(html).toContain("BLOCKED: paywall &lt;hit&gt;");
+    expect(html).toContain("Actions unavailable");
   });
 });
 


### PR DESCRIPTION
Closes #173. Stacked on #172 (events log) — base is `feature/172-events-log`.

## Scope

- **`/admin/summaries/<NNN>`** — server-rendered detail page (Pages Function `functions/admin/summaries/[id].ts`): summary content (title, 原題, language/contentType + topic chips, one-sentence lead, body paragraphs, scores table), summary status, link info (clickable URL, L<id>, status, run metrics fetch/AI ms + tokens), actions, and the per-run summarization log. Raw JSON stays at `/api/summaries/<NNN>` (linked from the page header).
- **Actions moved out of lists.** Dismiss / re-open / re-summarize now live only on the detail page; the inbox and console lists are read-mostly (NNN navigates to the detail page). The console keeps only retry-on-blocked. The logs page NNN subjects also point to the detail page.
- **Re-summarize** (confirm-gated: "overwrites content under the same NNN and spends tokens") uses the existing semantics: `PATCH /api/links/:id {status:'new'}` on a summarized link whose summary is NOT dismissed re-enqueues, and the DO reuses the link's NNN. Re-open of a dismissed summary remains an instant flag flip.
- **Per-run log**: merges `/api/events?summary_id=<NNN>` and `?link_id=<id>`, deduped by event id, newest-first — every historical run incl. failures (reason, model, ms, tokens).

## Design

- HTML building extracted into a pure renderer `functions/_lib/summary_page.ts` so vitest can pin the invariants without D1: **all user/LLM content is escaped**; **dismissed summaries render metadata + "content hidden while dismissed" and never the body** (the content column still exists); blocked stubs render as escaped raw text; no external libs.
- Cloudflare Access walls `/admin/*` at the edge (primary auth); `authorize()` in the function is defense-in-depth.
- No new migration; no worker changes; dismiss/flag semantics untouched.

## Verification (production)

- `npm run check` (tsc) and `npm test` pass — 12 tests incl. 3 new renderer tests (escaping, dismissed-hides-body, blocked stub / no-link fallback).
- Deployed; `curl /admin/summaries/003` unauthenticated → **302 to gentle-hill-7034.cloudflareaccess.com** (Access wall confirmed; page HTML itself verified via the renderer unit tests).
- E2E on a fresh test link (`en.wikipedia.org/wiki/Software_agent`, L11 → NNN 006):
  - summarized in ~37s (`summary.created`, gemini-3-flash-preview)
  - **dismiss** → summary `dismissed`, API returns `content: null`; `link.dismissed` + `summary.dismissed` events
  - **re-open** → instant flip back (`updated_at` unchanged, content restored, link `summarized`); `link.reopened` + `summary.restored` events
  - **re-summarize** (`PATCH {status:'new'}` while summary not dismissed) → `link.reopened {requeued:true}`, second `summary.created` for the **same NNN 006**, `updated_at` moved `14:58:27 → 14:59:56`
  - cleanup: test link + summary rows deleted via `wrangler d1 execute`; NNN 006 was the top id with nothing newer, so `next_summary_id` reset 7 → 6 (no gap). Events kept (append-only audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)