### PR TITLE
Platform: knowledge guide + staging environment (#177) + link detail rework + step-level events (#178)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This repository creates weekly curated journals about Generative AI in coding, following a systematic 14-step workflow.
 
+## Cloud Summarization Platform (in progress — epic #155)
+
+STEP_02 (gather + summarize) is being ported to a Cloudflare platform under
+`platform/`: submit a URL from anywhere → it is summarized in the cloud
+(Gemini) into a D1 collection, viewable at gen-ai-journal.pages.dev. The local
+editorial workflow (STEP_03 onward) is unchanged and remains canonical until
+the staged cutover (#165). **Before working on `platform/`, read
+[platform/IMPLEMENTATION_GUIDE.md](platform/IMPLEMENTATION_GUIDE.md)** — the
+knowledge doc covering architecture, the NNN-vs-link-id numbering semantics,
+dismiss/re-open behavior, the model decision, deploy workflow, and the gotchas
+learned building it. `platform/README.md` is the terse operational reference.
+
 # Editorial Guidelines
 
 ## Language Requirements

--- a/platform/IMPLEMENTATION_GUIDE.md
+++ b/platform/IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,310 @@
+# Cloud Summarization Platform — Implementation Guide
+
+Knowledge document for the `platform/` Cloudflare implementation (epic #155):
+architecture, decisions, semantics, and the lessons learned building it. Read
+this before extending or debugging the platform. `platform/README.md` is the
+terse operational reference; **this file is the "why" and "how it was built".**
+
+---
+
+## 1. What it is (mental model)
+
+The platform ports **STEP_02 (gather + summarize) to the cloud** so a URL
+submitted from any device becomes a stored Japanese summary with no laptop
+involved. Editorial work (STEP_03 onward — curation, assembly) stays local.
+
+**The design is hub-and-spoke. The summary collection (D1) is the hub:**
+
+- **Producers** write summaries in: the cloud pipeline (default), and
+  `push_summaries.py` (local fallback for what the cloud fails closed on — #168).
+- **Consumers** read summaries out: the admin console, the detail page, the
+  website (#162), and `generate_sources.py` (the STEP_03 handoff — #168).
+
+Producers and consumers never talk to each other directly. This is why the
+model is swappable and why each piece could ship independently.
+
+---
+
+## 2. Architecture
+
+Two worlds, one seam (the D1 collection):
+
+```
+LOCAL (editorial, unchanged)          CLOUDFLARE (gather · summarize · store · serve)
+────────────────────────────          ──────────────────────────────────────────────
+Claude Code STEP_03+                   Pages project "gen-ai-journal"
+curation / assembly                      functions/  = HTTP API (Pages Functions, TS)
+generate_sources.py (#168) ◄──reads──    public/     = submit · inbox · admin console/logs
+call-gemini.py (fallback) ──pushes──►    D1 "gen-ai-journal-db" = links · summaries · settings · events
+                                       Worker "gen-ai-journal-pipeline"
+                                         SummarizerDO = alarm-driven summarization queue
+                                       Gemini API (summarization model — see §7)
+```
+
+**Two separately deployed Cloudflare units, one shared D1:**
+
+1. **Pages project `gen-ai-journal`** (`platform/`) — static admin pages +
+   `functions/` HTTP API. Deploy: `npm run deploy`.
+2. **Worker `gen-ai-journal-pipeline`** (`platform/worker/`) — hosts the
+   `SummarizerDO` Durable Object. Deploy: `npm run deploy:worker`.
+
+The Pages project binds the DO by `script_name` (cross-deployable binding),
+so link submission can kick the pipeline while the two stay independent.
+
+**Why a separate Worker at all:** Pages Functions cannot host Durable Object
+classes or cron. The pipeline needs a durable, alarm-driven queue (debounce +
+serial processing + retry), so it lives in a companion Worker. Everything
+user-facing (API, pages, Access) stays on Pages.
+
+---
+
+## 3. Infrastructure inventory (reproducible)
+
+Created once via `wrangler` (authenticated as `syo.online@gmail.com`, account
+"Gen AI Journal" `b3c944b809c5ca6678d2cc26fbb3c57c`). All free tier.
+
+| Resource | Identifier | Created with |
+|---|---|---|
+| Pages project | `gen-ai-journal` → gen-ai-journal.pages.dev | `wrangler pages project create` |
+| Worker | `gen-ai-journal-pipeline` | `wrangler deploy` (from worker/) |
+| D1 database | `gen-ai-journal-db` `41a485fb-…` | `wrangler d1 create` |
+| KV namespace | `REBUILD_THROTTLE` `1d583e69…` | `wrangler kv namespace create` (for #163) |
+| Zero Trust team | `gentle-hill-7034` | dashboard onboarding (one-time) |
+| Access application | walls `/submit` `/inbox` `/admin/*` | dashboard, allow-email policy, One-time PIN |
+| workers.dev subdomain | `gen-ai-journal` | required before first `wrangler deploy` |
+
+**Secrets** (never in git; set via `wrangler … secret put`):
+- `API_BEARER_TOKEN` — on Pages **and** the worker (worker uses it for `/eval`).
+  Mirror value in `scripts/.env` as `PLATFORM_API_TOKEN` for local tooling.
+- `GEMINI_API_KEY` — on the worker (summarization inference).
+
+Non-secret config is in the two `wrangler.jsonc` `vars` blocks (team domain,
+Access `POLICY_AUD`, `SUMMARIZE_MODEL`, char limits).
+
+**wrangler's OAuth token has NO Zero Trust scope** — the Access app must be
+configured in the dashboard (or with a separately-minted API token), not the CLI.
+
+---
+
+## 4. Repository layout
+
+```
+platform/
+  wrangler.jsonc              Pages config: D1 + KV + DO bindings, Access vars
+  package.json / tsconfig     npm run check (tsc) · test (vitest) · deploy · deploy:worker
+  migrations/NNNN_*.sql        D1 schema, applied in order (idempotent tracking table)
+  functions/                   Pages Functions = the HTTP API
+    _lib/auth.ts               authorize() → "bearer" | Access email | null (§8)
+    _lib/summaries.ts          THE write path: validate, blocked-stub detect, upsert, allocateId
+    _lib/util.ts               sanitizeUrl/validateUrl (mirror scripts/check_link.py)
+    _lib/enqueue.ts            kick the SummarizerDO
+    _lib/events.ts             logEvent() fire-and-forget audit emitter
+    _lib/summary_page.ts       pure HTML renderer for the detail page (unit-tested)
+    api/links/{index,[id]}.ts  submit+list · PATCH (dismiss/reopen/retry)
+    api/summaries/{index,[id]} bulk upsert · list · detail (dismissed→content:null)
+    api/cycle.ts               registry state · rollover
+    api/pipeline.ts            console feed (joined view)
+    api/events.ts              audit query
+    admin/summaries/[id].ts    server-rendered detail page (#173)
+  public/                      submit/ inbox/ admin/pipeline/ admin/logs/  (static)
+  worker/
+    wrangler.jsonc             Worker config: D1 + AI + DO binding
+    src/index.ts               SummarizerDO (queue) + default fetch (/eval seam)
+    src/core.ts                summarizeUrl(): the pipeline steps, shared with /eval
+    src/prompt.generated.ts    GENERATED — uv run scripts/build_prompt_module.py
+  tests/unit.test.ts           vitest over the pure logic
+```
+
+Local companions in `scripts/`: `pull_inbox.py` (legacy parallel-run tool),
+`build_prompt_module.py` (regenerates the worker prompt from
+`prompts/summarize-json.prompt` + criteria + persona).
+
+---
+
+## 5. The pipeline (how a URL becomes a summary)
+
+1. `POST /api/links` — sanitize + validate + dedupe → insert `links` row
+   (`status=new`), then (if `AUTO_SUMMARIZE=true`) kick the DO via `waitUntil`.
+2. **SummarizerDO** debounces (~20s alarm), then processes one link per alarm
+   firing (2s spacing), recovering stale `queued` claims (15 min).
+3. `summarizeUrl()` (worker/src/core.ts): fetch (25s timeout) → **charset-aware
+   decode** → HTMLRewriter text extraction → min-chars gate (200) → model call
+   (Gemini, §7) with the summary-v1 JSON schema → validate → enforce invariants
+   in code (verbatim URL, drop `originalTitle` for `ja`, stamp metadata).
+4. On success: **allocate NNN** from the registry (or reuse the link's existing
+   `summary_id`) → `writeSummary()` upsert → link `status=summarized`.
+5. On any content failure: **fail closed** — link `status=blocked` + reason, no
+   NNN spent. Infra failures (D1/AI outage) rethrow so the alarm retries.
+6. Every run emits events (`summary.created` / `pipeline.blocked`) and updates
+   the link's run-metric columns (fetch_ms, ai_ms, tokens).
+
+**Fail-closed cases** (all become `blocked`, never a hallucinated summary):
+PDF (Content-Type/`.pdf` → regenerate locally, #168), non-HTML, HTTP error,
+thin extraction (bot-blocked/JS pages), model error, invalid model output,
+no active cycle.
+
+---
+
+## 6. Numbering & status semantics (the part that caused the most confusion)
+
+**Two numbers exist — keep them straight:**
+
+- **NNN** (`summaries.id`) — the journal's number, the ONLY one with editorial
+  meaning. **Per-cycle** (resets at rollover), zero-padded, assigned **only on
+  successful summarization**, **reused** on re-summarize, **stays spent** on
+  dismissal (gaps are honest). Used in filenames, `sources.md`, site URLs
+  `/journals/<date>/<NNN>/`, and `/api/summaries/<NNN>`. **This is the only
+  number shown in the UI.**
+- **link id** (`links.id`, shown discreetly as `L<n>`) — a technical row id.
+  Assigned at submission, counts everything ever (incl. dismissed/blocked/tests),
+  never resets. Its only job: a stable target for actions (`PATCH /api/links/7`)
+  and the subject key in `/admin/logs`. **Zero editorial meaning.**
+
+The registry (`settings` table: `current_journal_date`, `next_summary_id`)
+makes the cloud the ID authority. `POST /api/cycle` rolls over and seeds the
+counter (during parallel-run, seed from the real `sources.md` max + 1).
+
+**Link statuses:** `new` (shown as *generating*) → `queued` → `summarized` /
+`blocked`; `dismissed`. (`consumed` was removed in migration 0007 — it was a
+dead pull-based-design leftover; publication is tracked on *summaries* via
+`journal_date`, not on links.)
+
+**Summary statuses:** `workdesk` → `published` (at journal time, via
+`journal_date`); `blocked`; `dismissed`.
+
+**Dismiss is a reversible flag, content-hidden-only** (settled through several
+iterations):
+- Dismissing a link flags its summary `dismissed` — the row **stays**, nothing
+  is deleted.
+- The detail endpoint returns dismissed summaries with **`content: null`** but
+  all metadata intact; `?status=workdesk` excludes them; `?status=dismissed`
+  lists them.
+- Re-open **flips the flag back instantly** — no regeneration, no token spend.
+  Regeneration only happens for `blocked`/never-summarized links (real retry),
+  or an explicit **re-summarize** (detail page) which reuses the same NNN.
+
+---
+
+## 7. Model decision (#167)
+
+**`gemini-3-flash-preview` via the direct Gemini API** — the same model as the
+entire archive, so quality parity is by construction and cost is unchanged
+($0 delta; same key/usage as the local pipeline).
+
+Why not Workers AI (the reflex choice for "AI on Cloudflare"):
+1. **Open-weight only** — Gemini/GPT/Claude aren't on it. The requirement is to
+   keep Gemini.
+2. **Free neuron budget too small** — screening exhausted the daily 10k neurons
+   after ~15–20 heavy calls (`AiError 4006`) ≈ 15–25 summaries/day vs ~300/week.
+
+The pipeline routes by model prefix: `gemini-*` → Gemini `generateContent`
+(structured output via `responseSchema`); `@cf/*` → Workers AI. Switchable via
+the `SUMMARIZE_MODEL` var with **no code change** — Workers AI stays a viable
+fallback (best open model screened: `@cf/meta/llama-3.3-70b-instruct-fp8-fast`).
+Full evidence: `evaluations/2026-07-06-model-selection/CONCLUSION.md`.
+
+---
+
+## 8. Auth model
+
+| Caller | Mechanism |
+|---|---|
+| Local scripts / eval | `Authorization: Bearer <API_BEARER_TOKEN>` |
+| Browser (submit/inbox/admin) | Cloudflare Access wall on those paths; the `CF_Authorization` JWT is **signature-verified in-function** (`_lib/auth.ts`, team JWKS + `aud`/`iss`/`exp`) for the `/api/*` calls those pages make |
+| Readers | public GETs on summaries/cycle only |
+
+**`/api/*` is deliberately NOT behind the Access wall** — machines must reach
+it. So each API handler calls `authorize()` itself; anonymous `/api/*` → 401.
+The pages under `/admin/*` `/submit` `/inbox` ARE walled (a new `/admin/…` path
+is covered automatically). `authorize()` returns `"bearer"`, the Access email,
+or `null`.
+
+---
+
+## 9. Deploy & dev workflow
+
+```bash
+# from platform/
+npm run check          # tsc --noEmit (strict) — ALWAYS before deploy; esbuild does NOT typecheck
+npm test               # vitest unit tests (pure logic)
+npm run deploy         # Pages (functions + static)
+npm run deploy:worker  # pipeline Worker (DO)
+
+# schema change: add migrations/NNNN_name.sql, then BOTH:
+wrangler d1 migrations apply gen-ai-journal-db --local
+wrangler d1 migrations apply gen-ai-journal-db --remote
+
+# local dev of the whole stack (local D1 + .dev.vars bearer):
+wrangler pages dev --port 8788
+
+# live structured run logs:
+wrangler tail gen-ai-journal-pipeline
+```
+
+Deploy is direct-upload (doesn't consume the Pages Git-build quota). Each
+deploy is an immutable snapshot; `--branch main` also makes it production.
+
+---
+
+## 10. Lessons learned (gotchas that cost real time)
+
+- **esbuild strips types without checking them.** A type error deploys happily.
+  `npm run check` (tsc) is the safety net — run it before every deploy.
+- **Never cap Gemini output tokens.** A `maxOutputTokens: 4096` cap truncated
+  the JSON mid-string on long articles → parse failures. The local pipeline has
+  no cap; the cloud one must not either.
+- **Japanese sites serve Shift_JIS / EUC-JP.** HTMLRewriter assumes UTF-8, so
+  the body must be re-decoded by declared charset (header + `<meta>` sniff)
+  first, or titles come out as mojibake. Found via itmedia.co.jp.
+- **SQLite treats NULLs as distinct in a PRIMARY KEY.** Workdesk rows have
+  `journal_date IS NULL`, so upserts need a `UNIQUE (id, ifnull(journal_date,''))`
+  index guard (migration 0003).
+- **SQLite can't alter CHECK constraints.** Extending a status enum means a
+  table rebuild (copy → drop → rename), as in migrations 0004/0006/0007.
+- **Workers AI structured output ≠ Gemini's.** Different models wrap JSON
+  differently; only some honor `response_format`/`json_schema`.
+- **Access can't be scripted with wrangler's token** — dashboard or a scoped
+  API token only.
+- **Audit events outlive their subject** — deleting a link keeps its events by
+  design; test/cleanup artifacts linger in `/admin/logs` (annotate test actions
+  with `detail.note`).
+
+---
+
+## 11. Evaluations convention
+
+One-shot investigations live under `evaluations/<YYYY-MM-DD-topic>/`
+(self-contained: runner + raw results + report + `CONCLUSION.md`), indexed in
+`evaluations/README.md`. **Product code never imports from `evaluations/`.**
+The stable seam for pipeline investigations is the worker's bearer-protected
+`POST /eval {url, model?}` — it runs the exact `summarizeUrl()` path **without
+persisting** (no D1 write, no NNN spent), returning summary + timings + tokens.
+
+---
+
+## 12. How to extend
+
+- **New API endpoint**: add `functions/api/<name>.ts` (or `[id].ts` for a
+  param); call `authorize()` first for writes; return via `json()`/`error()`
+  from `_lib/util.ts`.
+- **New DB column/table**: add the next `migrations/NNNN_*.sql`; apply local +
+  remote; rebuild the table if you're touching a CHECK constraint.
+- **New event type**: emit via `logEvent()` — it's fire-and-forget and shared
+  with the worker.
+- **Change the model**: set `SUMMARIZE_MODEL` in `worker/wrangler.jsonc` (add
+  `GEMINI_API_KEY` for gemini-*, nothing for `@cf/*`); re-eval via `/eval`
+  before trusting a new one (see §11).
+- **Change the prompt/criteria**: edit `prompts/summarize-json.prompt` (or the
+  criteria/persona files it includes), then
+  `uv run scripts/build_prompt_module.py` to regenerate `prompt.generated.ts`.
+
+---
+
+## 13. Status & roadmap (epic #155)
+
+Done: link intake (#159), collection store + registry (#160), pipeline (#166),
+model decision (#167), console (#161), events + `/admin/logs` (#172), detail
+page (#173), plus a polish pass (#171). Pending: site reads the collection
+(#162), rebuild automation (#163), local bridge scripts (#168), and the staged
+cutover governance (#165) — the current local workflow stays canonical until
+#165's criteria pass. See the epic for the live checklist.

--- a/platform/IMPLEMENTATION_GUIDE.md
+++ b/platform/IMPLEMENTATION_GUIDE.md
@@ -168,8 +168,16 @@ Local companions in `scripts/`: `pull_inbox.py` (legacy parallel-run tool),
    `summary_id`) → `writeSummary()` upsert → link `status=summarized`.
 5. On any content failure: **fail closed** — link `status=blocked` + reason, no
    NNN spent. Infra failures (D1/AI outage) rethrow so the alarm retries.
-6. Every run emits events (`summary.created` / `pipeline.blocked`) and updates
-   the link's run-metric columns (fetch_ms, ai_ms, tokens).
+6. Every run emits events (#172, step events #178): `pipeline.run_started` at
+   claim, then `pipeline.fetched` → `pipeline.extracted` →
+   `pipeline.model_requested` → `pipeline.model_responded` along the way,
+   closed by `summary.created` (first write) / `summary.updated` (overwrite
+   under the link's existing NNN — re-summarize/retry of a summarized link) /
+   `pipeline.blocked`. All events of one attempt share a `run` marker (ISO
+   timestamp captured at claim) in `detail`, so retries group into distinct
+   runs. The DO passes a `logEvent`-backed emitter into `summarizeUrl()`;
+   `/eval` passes none (no-op — eval persists nothing). The link's run-metric
+   columns (fetch_ms, ai_ms, tokens) update as before.
 
 **Fail-closed cases** (all become `blocked`, never a hallucinated summary):
 PDF (Content-Type/`.pdf` → regenerate locally, #168), non-HTML, HTTP error,
@@ -325,7 +333,8 @@ One-shot investigations live under `evaluations/<YYYY-MM-DD-topic>/`
 `evaluations/README.md`. **Product code never imports from `evaluations/`.**
 The stable seam for pipeline investigations is the worker's bearer-protected
 `POST /eval {url, model?}` — it runs the exact `summarizeUrl()` path **without
-persisting** (no D1 write, no NNN spent), returning summary + timings + tokens.
+persisting** (no D1 write, no NNN spent, no step events — it passes no step
+emitter, #178), returning summary + timings + tokens.
 
 ---
 
@@ -337,7 +346,8 @@ persisting** (no D1 write, no NNN spent), returning summary + timings + tokens.
 - **New DB column/table**: add the next `migrations/NNNN_*.sql`; apply local +
   remote; rebuild the table if you're touching a CHECK constraint.
 - **New event type**: emit via `logEvent()` — it's fire-and-forget and shared
-  with the worker.
+  with the worker. New *pipeline step* events go through the `StepEmitter`
+  callback of `summarizeUrl()` (#178) so `/eval` stays persistence-free.
 - **Change the model**: set `SUMMARIZE_MODEL` in `worker/wrangler.jsonc` (add
   `GEMINI_API_KEY` for gemini-*, nothing for `@cf/*`); re-eval via `/eval`
   before trusting a new one (see §11).

--- a/platform/IMPLEMENTATION_GUIDE.md
+++ b/platform/IMPLEMENTATION_GUIDE.md
@@ -84,6 +84,38 @@ Access `POLICY_AUD`, `SUMMARIZE_MODEL`, char limits).
 **wrangler's OAuth token has NO Zero Trust scope** — the Access app must be
 configured in the dashboard (or with a separately-minted API token), not the CLI.
 
+### Staging environment (#177)
+
+A full staging mirror lives entirely in Cloudflare, isolated from production at
+the data plane (its own D1 — the hub). Compute is the Pages **`preview`**
+environment plus the Worker's **`staging`** wrangler environment; config is the
+two `env` blocks in the `wrangler.jsonc` files (`env.preview` on Pages,
+`env.staging` on the worker). All free tier.
+
+| Resource (staging) | Identifier |
+|---|---|
+| D1 database | `gen-ai-journal-db-staging` `8217e2ac-…` |
+| KV namespace | `REBUILD_THROTTLE_staging` `65760529…` |
+| Worker | `gen-ai-journal-pipeline-staging` (deploy: `--env staging`) |
+| Pages env | `preview` → staging.gen-ai-journal.pages.dev (deploy: `--branch staging`) |
+| Access application | **separate app**, own AUD `86817f76…`, walls the same paths on `staging.…` |
+
+- **The isolation seam is `staging Worker → staging D1`.** The `SummarizerDO`
+  writes through the worker's own `DB` binding, so the one thing that must never
+  leak is the worker's D1 id. The Pages `env.preview` DO binding therefore sets
+  `script_name: gen-ai-journal-pipeline-staging` — the staging UI enqueues into
+  the staging pipeline, never prod.
+- **`POLICY_AUD` differs per environment.** Staging has its own Access
+  application (the prod app's 5-destination limit forced the split), so
+  `env.preview.POLICY_AUD` = the staging app's AUD, verified in-function against
+  the staging-issued JWT. `TEAM_DOMAIN` stays the same (one Zero Trust team).
+- **Secrets are per-environment and NOT shared:** `GEMINI_API_KEY` +
+  `API_BEARER_TOKEN` on the worker `--env staging`; `API_BEARER_TOKEN` on the
+  Pages **Preview** scope. Keep the staging bearer separate from prod (mirror it
+  locally as `PLATFORM_API_TOKEN_STAGING` in `scripts/.env`).
+- Seed the staging cycle once after first deploy: `POST /api/cycle {date, next_id}`
+  (else every submission fails closed on "no active cycle").
+
 ---
 
 ## 4. Repository layout
@@ -229,10 +261,14 @@ npm run check          # tsc --noEmit (strict) — ALWAYS before deploy; esbuild
 npm test               # vitest unit tests (pure logic)
 npm run deploy         # Pages (functions + static)
 npm run deploy:worker  # pipeline Worker (DO)
+npm run deploy:staging         # Pages preview → staging.gen-ai-journal.pages.dev (#177)
+npm run deploy:worker:staging  # staging pipeline Worker (Worker env.staging)
 
-# schema change: add migrations/NNNN_name.sql, then BOTH:
+# schema change: add migrations/NNNN_name.sql, then apply to BOTH DBs (#177 —
+# migrations now fan out; the staging mirror uses the Pages env.preview binding):
 wrangler d1 migrations apply gen-ai-journal-db --local
 wrangler d1 migrations apply gen-ai-journal-db --remote
+wrangler d1 migrations apply gen-ai-journal-db-staging --remote --env preview
 
 # local dev of the whole stack (local D1 + .dev.vars bearer):
 wrangler pages dev --port 8788
@@ -265,6 +301,12 @@ deploy is an immutable snapshot; `--branch main` also makes it production.
   differently; only some honor `response_format`/`json_schema`.
 - **Access can't be scripted with wrangler's token** — dashboard or a scoped
   API token only.
+- **Pages secrets apply only to NEW deployments.** `wrangler pages secret put …
+  --env preview` updates the project store but does NOT reach the currently-live
+  deployment — a Function keeps seeing the old (or `undefined`) value until you
+  redeploy. A freshly-set staging `API_BEARER_TOKEN` 401'd every `/api/*` call
+  until `npm run deploy:staging` re-ran (#177). (Contrast Worker `secret put`,
+  which takes effect immediately.)
 - **Audit events outlive their subject** — deleting a link keeps its events by
   design; test/cleanup artifacts linger in `/admin/logs` (annotate test actions
   with `detail.note`).

--- a/platform/IMPLEMENTATION_GUIDE.md
+++ b/platform/IMPLEMENTATION_GUIDE.md
@@ -137,7 +137,8 @@ platform/
     api/cycle.ts               registry state · rollover
     api/pipeline.ts            console feed (joined view)
     api/events.ts              audit query
-    admin/summaries/[id].ts    server-rendered detail page (#173)
+    admin/links/[id].ts        server-rendered detail page (#173), keyed by link id
+    admin/summaries/[id].ts    NNN → 302 redirect to /admin/links/<id>
   public/                      submit/ inbox/ admin/pipeline/ admin/logs/  (static)
   worker/
     wrangler.jsonc             Worker config: D1 + AI + DO binding
@@ -186,11 +187,15 @@ no active cycle.
   successful summarization**, **reused** on re-summarize, **stays spent** on
   dismissal (gaps are honest). Used in filenames, `sources.md`, site URLs
   `/journals/<date>/<NNN>/`, and `/api/summaries/<NNN>`. **This is the only
-  number shown in the UI.**
+  number with editorial meaning in the UI.**
 - **link id** (`links.id`, shown discreetly as `L<n>`) — a technical row id.
   Assigned at submission, counts everything ever (incl. dismissed/blocked/tests),
-  never resets. Its only job: a stable target for actions (`PATCH /api/links/7`)
-  and the subject key in `/admin/logs`. **Zero editorial meaning.**
+  never resets. Its only job: a stable target for actions (`PATCH /api/links/7`),
+  the subject key in `/admin/logs`, and the key of the admin detail page
+  (`/admin/links/<id>`) — keyed by link id for process observability, so
+  blocked/failed runs that never earned an NNN are inspectable too
+  (`/admin/summaries/<NNN>` just redirects; NNN remains the editorial number).
+  **Zero editorial meaning.**
 
 The registry (`settings` table: `current_journal_date`, `next_summary_id`)
 makes the cloud the ID authority. `POST /api/cycle` rolls over and seeds the

--- a/platform/README.md
+++ b/platform/README.md
@@ -26,16 +26,21 @@ functions/            Pages Functions = the HTTP API
   api/cycle.ts        GET registry state, POST rollover (seed counter per #165 rule)
   api/pipeline.ts     joined operational view for the console
   api/events.ts       GET audit trail: ?limit= (≤200) &event= &summary_id= &link_id=
-  admin/summaries/    GET /admin/summaries/:id — server-rendered summary detail
-                      page (#173): content, link + run metrics, actions
-                      (dismiss / re-open / re-summarize), per-run event log
-  _lib/summary_page.ts  pure HTML renderer for the detail page (unit-tested)
+  admin/links/        GET /admin/links/:id — server-rendered detail page (#173),
+                      keyed by link id so EVERY run — blocked/failed included —
+                      is inspectable: status, content (when summarized), run
+                      metrics, actions (dismiss / re-open / retry / re-summarize),
+                      per-run event log
+  admin/summaries/    GET /admin/summaries/:NNN → 302 to the latest link's
+                      /admin/links/:id (raw JSON stays at /api/summaries/:NNN)
+  _lib/summary_page.ts  pure HTML renderer for the link detail page (unit-tested)
 public/               static, Access-protected where sensitive
   submit/ inbox/      link intake UI + bookmarklet (+ latest-events panel)
   admin/pipeline/     operations console: states, errors, metrics, retry, rollover
   admin/logs/         events log: full audit trail, filterable, auto-refresh
-                      Lists are read-mostly (#173): NNN links navigate to the
-                      detail page; only retry-on-blocked stays on the console
+                      Lists are read-mostly (#173): L<n> tokens navigate to the
+                      link detail page (NNN stays as text); only retry-on-blocked
+                      stays on the console
 worker/               companion Worker "gen-ai-journal-pipeline"
   src/index.ts        SummarizerDO: alarm-driven queue (debounce 20s, serial,
                       stale-claim recovery, infra-retry via alarm backoff)

--- a/platform/README.md
+++ b/platform/README.md
@@ -87,8 +87,16 @@ wrangler tail gen-ai-journal-pipeline                     # live structured run 
 - Blocked = fail-closed with a reason on the link; PDFs & bot-blocked pages
   are regenerated locally and pushed (#168, permanent fallback path).
 - Every summarization-lifecycle interaction lands in the append-only `events`
-  table (#172): link submitted/dismissed/reopened, summary created/dismissed/
-  restored, pipeline blocked (with metrics), cycle rolled. Events survive link
-  deletion; scope is summarization only until the publish phase (#163) adds
-  journal events. View at `/admin/logs`, query via `GET /api/events`.
+  table (#172): link submitted/dismissed/reopened, summary created/updated/
+  dismissed/restored, pipeline blocked (with metrics), cycle rolled. Each
+  pipeline run also emits step events (#178) — `pipeline.run_started` →
+  `.fetched` → `.extracted` → `.model_requested` → `.model_responded` — all
+  sharing a `run` marker (ISO ts captured at claim) in `detail` with the
+  closing created/updated/blocked event, so retries group into distinct runs.
+  `summary.updated` = overwrite under an existing NNN (re-summarize);
+  `summary.created` stays for first writes. The worker `/eval` path passes no
+  step emitter → persists nothing. Events survive link deletion; scope is
+  summarization only until the publish phase (#163) adds journal events. View
+  at `/admin/logs` (one-line rows, hover for full detail; step noise hidden
+  by default), query via `GET /api/events`.
 - Secrets: `API_BEARER_TOKEN` (Pages + worker), `GEMINI_API_KEY` (worker).

--- a/platform/README.md
+++ b/platform/README.md
@@ -6,6 +6,7 @@ decided in #167), admin console (#161). The journal website is NOT hosted
 here yet — see the epic for later phases.
 
 Live: **https://gen-ai-journal.pages.dev** · Pipeline worker: `gen-ai-journal-pipeline`
+Staging (#177): **https://staging.gen-ai-journal.pages.dev** · worker `gen-ai-journal-pipeline-staging` · isolated D1 `gen-ai-journal-db-staging`
 
 ## Layout
 
@@ -52,7 +53,10 @@ npm run check          # tsc --noEmit (run before every deploy)
 npm test               # vitest unit tests
 npm run deploy         # Pages (functions + static)
 npm run deploy:worker  # pipeline worker (DO)
-wrangler d1 migrations apply gen-ai-journal-db --remote   # after adding migrations/NNNN_*.sql
+npm run deploy:staging         # staging Pages preview (#177)
+npm run deploy:worker:staging  # staging pipeline worker
+wrangler d1 migrations apply gen-ai-journal-db --remote                 # after adding migrations/NNNN_*.sql
+wrangler d1 migrations apply gen-ai-journal-db-staging --remote --env preview  # …and the staging mirror (#177)
 wrangler tail gen-ai-journal-pipeline                     # live structured run logs
 ```
 

--- a/platform/README.md
+++ b/platform/README.md
@@ -87,8 +87,10 @@ wrangler tail gen-ai-journal-pipeline                     # live structured run 
 - Blocked = fail-closed with a reason on the link; PDFs & bot-blocked pages
   are regenerated locally and pushed (#168, permanent fallback path).
 - Every summarization-lifecycle interaction lands in the append-only `events`
-  table (#172): link submitted/dismissed/reopened, summary created/updated/
-  dismissed/restored, pipeline blocked (with metrics), cycle rolled. Each
+  table (#172): link submitted/dismissed/reopened/retried/resummarize_requested
+  (the `→ new` trigger is named by the editor's intent, from prior status),
+  summary created/updated/dismissed/restored, pipeline blocked (with metrics),
+  cycle rolled. Each
   pipeline run also emits step events (#178) — `pipeline.run_started` →
   `.fetched` → `.extracted` → `.model_requested` → `.model_responded` — all
   sharing a `run` marker (ISO ts captured at claim) in `detail` with the

--- a/platform/functions/_lib/events.ts
+++ b/platform/functions/_lib/events.ts
@@ -5,7 +5,13 @@
 
 export interface EventInput {
   actor: "editor" | "pipeline" | "system";
-  event: string; // link.submitted | link.dismissed | link.reopened | summary.created | summary.dismissed | summary.restored | pipeline.blocked | cycle.rolled
+  // link.submitted | link.dismissed | link.reopened
+  // summary.created | summary.updated | summary.dismissed | summary.restored
+  // pipeline.run_started | pipeline.fetched | pipeline.extracted |
+  //   pipeline.model_requested | pipeline.model_responded | pipeline.blocked
+  //   (step events + the closing event share a `run` marker in detail — #178)
+  // cycle.rolled
+  event: string;
   linkId?: number | null;
   summaryId?: string | null;
   detail?: Record<string, unknown> | null;

--- a/platform/functions/_lib/summary_page.ts
+++ b/platform/functions/_lib/summary_page.ts
@@ -142,11 +142,10 @@ export function renderErrorPage(subject: string, message: string): string {
   );
 }
 
-/** Rich render of summary-v1 JSON; falls back to <pre> for stubs/unparseable. */
+/** Rich render of summary-v1 JSON; falls back to <pre> for stubs/unparseable.
+ * Pure content — show or nothing; all status messaging lives in the result
+ * overview. Callers skip this entirely for dismissed summaries. */
 function contentHtml(s: SummaryRow): string {
-  if (s.status === "dismissed") {
-    return `<div class="notice">Content hidden while dismissed — re-open the link below to restore it. The row (and its content) still exists.</div>`;
-  }
   const raw = s.content ?? "";
   if (raw.trimStart().startsWith("BLOCKED")) {
     return `<section><h2>Blocked stub</h2><pre class="raw">${esc(raw)}</pre></section>`;
@@ -191,16 +190,42 @@ function contentHtml(s: SummaryRow): string {
   </section>`;
 }
 
-/** Shown instead of a content section when the link never produced a summary. */
-function noSummaryHtml(link: LinkRow): string {
+/** Result overview — the run's outcome at a glance, shown FIRST (before the
+ * log): status headline for every state (blocked reason, success NNN,
+ * dismissed, generating/queued) plus the last-run metrics. */
+function resultOverviewHtml(link: LinkRow, summary: SummaryRow | null): string {
+  let headline: string;
   if (link.status === "blocked") {
-    return `<div class="notice"><span class="err" style="font-weight:600">blocked</span> — ${esc(link.error ?? "(no reason recorded)")}<br>
-    Fail-closed: no summary was written, no NNN spent. Retry below, or regenerate locally and push (#168).</div>`;
+    headline = `<div class="notice"><span class="err" style="font-weight:600">blocked</span> —
+    fail-closed: no summary was written, no NNN spent. Retry below, or regenerate locally and push (#168).</div>`;
+  } else if (link.status === "dismissed") {
+    headline = summary
+      ? `<div class="notice">Dismissed — content hidden while dismissed. Re-open below to restore it instantly (no regeneration, no token spend; the row still exists).</div>`
+      : `<div class="notice">Dismissed before a summary was produced — re-open below to queue it.</div>`;
+  } else if (summary) {
+    headline = `<div class="notice">Summarized into <span class="nnn">NNN ${esc(summary.id)}</span> — content below the log.</div>`;
+  } else {
+    headline = `<div class="notice">No summary yet — the pipeline ${link.status === "queued" ? "has queued this link" : "will pick this link up shortly"}.</div>`;
   }
-  if (link.status === "dismissed") {
-    return `<div class="notice">Dismissed before a summary was produced — re-open below to queue it.</div>`;
+
+  const rows: string[] = [];
+  if (link.status === "blocked") {
+    rows.push(`<tr><td>reason</td><td class="err">${esc(link.error ?? "(no reason recorded)")}</td></tr>`);
   }
-  return `<div class="notice">No summary yet — the pipeline ${link.status === "queued" ? "has queued this link" : "will pick this link up shortly"}.</div>`;
+  if (summary) {
+    rows.push(
+      `<tr><td>summary</td><td><span class="nnn">NNN ${esc(summary.id)}</span> <span class="pill ${esc(summary.status)}">${esc(summary.status)}</span></td></tr>`,
+    );
+  }
+  if (link.processed_at) {
+    rows.push(
+      `<tr><td>last run</td><td>${fmtTs(link.processed_at)} · fetch ${fmtMs(link.fetch_ms)} + ai ${fmtMs(link.ai_ms)} · tokens ${link.tokens_in != null ? `${esc(link.tokens_in)}/${esc(link.tokens_out ?? "–")}` : "–"}</td></tr>`,
+    );
+  }
+
+  return `<section id="result"><h2>Result</h2>
+    ${headline}${rows.length ? `\n    <table class="kv"><tbody>\n      ${rows.join("\n      ")}\n    </tbody></table>` : ""}
+  </section>`;
 }
 
 function actionButtons(link: LinkRow): string {
@@ -239,9 +264,7 @@ function linkSectionHtml(link: LinkRow): string {
       <tr><td>url</td><td>${urlHtml(link.url)}</td></tr>
       <tr><td>link</td><td>L${Number(link.id)} <span class="pill ${esc(link.status)}">${esc(label)}</span></td></tr>
       ${link.note ? `<tr><td>note</td><td>${esc(link.note)}</td></tr>` : ""}
-      ${link.error ? `<tr><td>error</td><td class="err">${esc(link.error)}</td></tr>` : ""}
       <tr><td>submitted</td><td>${fmtTs(link.submitted_at)}</td></tr>
-      <tr><td>last run</td><td>${fmtTs(link.processed_at)} · fetch ${fmtMs(link.fetch_ms)} + ai ${fmtMs(link.ai_ms)} · tokens ${link.tokens_in != null ? `${esc(link.tokens_in)}/${esc(link.tokens_out ?? "–")}` : "–"}</td></tr>
     </tbody></table>
     ${actionButtons(link)}
   </section>`;
@@ -317,6 +340,8 @@ export function renderLinkPage(link: LinkRow, summary: SummaryRow | null): strin
   const body = `  <h1>L${Number(link.id)} <span class="pill ${esc(link.status)}">${esc(label)}</span>${summary ? ` <span class="nnn">NNN ${esc(summary.id)}</span>` : ""}</h1>
   <p class="sub">${sub}</p>
 
+${resultOverviewHtml(link, summary)}
+
   <section id="log"><h2>Summarization log</h2>
     <div class="tbl-wrap"><table>
       <thead><tr><th>time (UTC)</th><th>actor</th><th>event</th><th>detail</th></tr></thead>
@@ -325,7 +350,7 @@ export function renderLinkPage(link: LinkRow, summary: SummaryRow | null): strin
     <div id="log-empty" hidden style="color:var(--muted);font-size:13px;padding:10px 0 0">No events recorded for this link.</div>
   </section>
 
-${summary ? contentHtml(summary) : noSummaryHtml(link)}
+${summary && summary.status !== "dismissed" ? contentHtml(summary) : ""}
 
 ${linkSectionHtml(link)}
 

--- a/platform/functions/_lib/summary_page.ts
+++ b/platform/functions/_lib/summary_page.ts
@@ -93,6 +93,11 @@ const STYLE = `
     .pill.blocked { background: #fbe9e7; color: var(--bad); }
     .pill.dismissed { background: #f0f0ee; color: #888; }
     .notice { border: 1px dashed var(--line); border-radius: 6px; background: #faf9f6; color: var(--muted); padding: 14px 18px; font-size: 14px; margin-bottom: 16px; }
+    /* Result headline tinted by outcome (st-<link.status> on #result). */
+    #result.st-blocked .notice { border: 1px solid #efc4bd; background: #fbe9e7; color: var(--bad); }
+    #result.st-summarized .notice { border: 1px solid #bfd8c6; background: #e7f2ea; color: var(--ok); }
+    #result.st-new .notice, #result.st-queued .notice { border: 1px solid #ecd9b6; background: #fdf3e4; color: #8a5307; }
+    #result.st-dismissed .notice { border: 1px solid var(--line); background: #f0f0ee; color: #777; }
     pre.raw { background: #faf9f6; border: 1px solid var(--line); border-radius: 6px; padding: 12px 14px; font-size: 12.5px; overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
     table { border-collapse: collapse; width: 100%; font-size: 13px; }
     th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); padding: 5px 10px 5px 0; border-bottom: 1px solid var(--line); white-space: nowrap; }
@@ -226,8 +231,9 @@ function resultOverviewHtml(link: LinkRow, summary: SummaryRow | null): string {
     );
   }
 
-  return `<section id="result"><h2>Result</h2>
+  return `<section id="result" class="st-${esc(link.status)}"><h2>Result</h2>
     ${headline}${rows.length ? `\n    <table class="kv"><tbody>\n      ${rows.join("\n      ")}\n    </tbody></table>` : ""}
+    ${actionButtons(link)}
   </section>`;
 }
 
@@ -269,7 +275,6 @@ function linkSectionHtml(link: LinkRow): string {
       ${link.note ? `<tr><td>note</td><td>${esc(link.note)}</td></tr>` : ""}
       <tr><td>submitted</td><td>${fmtTs(link.submitted_at)}</td></tr>
     </tbody></table>
-    ${actionButtons(link)}
   </section>`;
 }
 

--- a/platform/functions/_lib/summary_page.ts
+++ b/platform/functions/_lib/summary_page.ts
@@ -317,10 +317,6 @@ export function renderLinkPage(link: LinkRow, summary: SummaryRow | null): strin
   const body = `  <h1>L${Number(link.id)} <span class="pill ${esc(link.status)}">${esc(label)}</span>${summary ? ` <span class="nnn">NNN ${esc(summary.id)}</span>` : ""}</h1>
   <p class="sub">${sub}</p>
 
-${summary ? contentHtml(summary) : noSummaryHtml(link)}
-
-${linkSectionHtml(link)}
-
   <section id="log"><h2>Summarization log</h2>
     <div class="tbl-wrap"><table>
       <thead><tr><th>time (UTC)</th><th>actor</th><th>event</th><th>detail</th></tr></thead>
@@ -328,6 +324,10 @@ ${linkSectionHtml(link)}
     </table></div>
     <div id="log-empty" hidden style="color:var(--muted);font-size:13px;padding:10px 0 0">No events recorded for this link.</div>
   </section>
+
+${summary ? contentHtml(summary) : noSummaryHtml(link)}
+
+${linkSectionHtml(link)}
 
   <nav><a href="/admin/pipeline">console</a><a href="/inbox">inbox</a><a href="/admin/logs">events log</a><a href="/submit">submit</a></nav>
 

--- a/platform/functions/_lib/summary_page.ts
+++ b/platform/functions/_lib/summary_page.ts
@@ -114,12 +114,20 @@ const STYLE = `
     /* The log is the page's main content — unwrap it from the card look so
        it doesn't read as just another parallel section. */
     #log { border: none; border-radius: 0; background: transparent; padding: 6px 0 10px; }
-    #log td.ts { white-space: nowrap; color: var(--muted); font-variant-numeric: tabular-nums; }
-    #log td.ev { font-family: ui-monospace, monospace; font-size: 11.5px; white-space: nowrap; }
+    /* One line per row (#178): fixed layout + nowrap/ellipsis on the flexible
+       cells; hovering a row shows the full content in the popover. */
+    #log table { table-layout: fixed; }
+    #log td.ts { white-space: nowrap; overflow: hidden; color: var(--muted); font-variant-numeric: tabular-nums; }
+    #log td.ev { font-family: ui-monospace, monospace; font-size: 11.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    #log td.ev.step { color: var(--muted); }
     #log .pill.editor { background: #e8eef5; color: #33567a; }
     #log .pill.pipeline { background: #fdf3e4; color: #8a5307; }
     #log .pill.system { background: #f0f0ee; color: #888; }
-    #log td.detail { color: #444; font-size: 12.5px; word-break: break-word; }
+    #log td.detail { color: #444; font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    #log-pop { position: fixed; z-index: 20; max-width: min(560px, 90vw); max-height: 60vh; overflow: auto;
+      background: #21252d; color: #f2efe9; font-family: ui-monospace, monospace; font-size: 12px; line-height: 1.5;
+      padding: 10px 12px; border-radius: 6px; white-space: pre-wrap; word-break: break-word;
+      box-shadow: 0 4px 18px rgba(0,0,0,.3); pointer-events: none; }
     nav { margin-top: 22px; font-size: 13.5px; }
     nav a { color: var(--accent); margin-right: 16px; }
 `;
@@ -306,6 +314,26 @@ const CLIENT_SCRIPT = `
         .join(" · ");
     }
 
+    // Hover popover (#178): rows are one line (ellipsized); hovering shows the
+    // full event name, timestamp, and pretty-printed detail JSON. Content is
+    // set via textContent only — never innerHTML of user data.
+    const pop = document.getElementById("log-pop");
+    const STEP_EVENTS = new Set(["pipeline.run_started", "pipeline.fetched", "pipeline.extracted", "pipeline.model_requested", "pipeline.model_responded"]);
+    function popText(e) {
+      let detail = e.detail || "";
+      try { detail = JSON.stringify(JSON.parse(detail), null, 2); } catch { /* leave raw */ }
+      return e.event + "\\n" + (e.ts || "") + " · " + e.actor + (detail ? "\\n\\n" + detail : "");
+    }
+    function placePop(x, y) {
+      pop.style.left = Math.max(8, Math.min(x + 14, window.innerWidth - pop.offsetWidth - 10)) + "px";
+      pop.style.top = Math.max(8, Math.min(y + 14, window.innerHeight - pop.offsetHeight - 10)) + "px";
+    }
+    function attachPop(tr, e) {
+      tr.addEventListener("mouseenter", (m) => { pop.textContent = popText(e); pop.hidden = false; placePop(m.clientX, m.clientY); });
+      tr.addEventListener("mousemove", (m) => placePop(m.clientX, m.clientY));
+      tr.addEventListener("mouseleave", () => { pop.hidden = true; });
+    }
+
     async function loadLog() {
       const qs = ["link_id=" + PAGE.linkId];
       if (PAGE.summaryId != null) qs.push("summary_id=" + encodeURIComponent(PAGE.summaryId));
@@ -330,9 +358,11 @@ const CLIENT_SCRIPT = `
         const actor = document.createElement("td");
         const pill = document.createElement("span"); pill.className = "pill " + e.actor; pill.textContent = e.actor;
         actor.appendChild(pill);
-        const ev = document.createElement("td"); ev.className = "ev"; ev.textContent = e.event;
+        const ev = document.createElement("td"); ev.className = STEP_EVENTS.has(e.event) ? "ev step" : "ev"; ev.textContent = e.event;
         const detail = document.createElement("td"); detail.className = "detail"; detail.textContent = fmtDetail(e.detail);
+        detail.title = fmtDetail(e.detail); // native tooltip as a supplement to the popover
         tr.appendChild(ts); tr.appendChild(actor); tr.appendChild(ev); tr.appendChild(detail);
+        attachPop(tr, e);
         rows.appendChild(tr);
       }
     }
@@ -352,10 +382,12 @@ ${resultOverviewHtml(link, summary)}
 
   <section id="log"><h2>Summarization log</h2>
     <div class="tbl-wrap"><table>
+      <colgroup><col style="width:152px"><col style="width:76px"><col style="width:186px"><col></colgroup>
       <thead><tr><th>time (UTC)</th><th>actor</th><th>event</th><th>detail</th></tr></thead>
       <tbody id="log-rows"></tbody>
     </table></div>
     <div id="log-empty" hidden style="color:var(--muted);font-size:13px;padding:10px 0 0">No events recorded for this link.</div>
+    <div id="log-pop" hidden></div>
   </section>
 
 ${summary && summary.status !== "dismissed" ? contentHtml(summary) : ""}

--- a/platform/functions/_lib/summary_page.ts
+++ b/platform/functions/_lib/summary_page.ts
@@ -106,6 +106,9 @@ const STYLE = `
     .actions button { font-size: 13px; border: 1px solid var(--line); background: #fff; border-radius: 5px; padding: 5px 14px; cursor: pointer; }
     .actions button.warn { border-color: var(--accent); color: var(--accent); font-weight: 600; }
     .actions .hint { font-size: 12px; color: var(--muted); align-self: center; }
+    /* The log is the page's main content — unwrap it from the card look so
+       it doesn't read as just another parallel section. */
+    #log { border: none; border-radius: 0; background: transparent; padding: 6px 0 10px; }
     #log td.ts { white-space: nowrap; color: var(--muted); font-variant-numeric: tabular-nums; }
     #log td.ev { font-family: ui-monospace, monospace; font-size: 11.5px; white-space: nowrap; }
     #log .pill.editor { background: #e8eef5; color: #33567a; }

--- a/platform/functions/_lib/summary_page.ts
+++ b/platform/functions/_lib/summary_page.ts
@@ -1,6 +1,9 @@
-// Summary detail page renderer (#173) — pure HTML-building for
-// /admin/summaries/<NNN>. Kept out of the route file so vitest can pin the
-// invariants (dismissed hides body, user content is escaped) without a D1.
+// Link detail page renderer (#173) — pure HTML-building for
+// /admin/links/<id>. Keyed by link id so EVERY submitted link — blocked and
+// failed runs included, which never earn an NNN — has an inspectable page
+// with its per-run summarization log. Kept out of the route file so vitest
+// can pin the invariants (dismissed hides body, user content is escaped)
+// without a D1.
 //
 // Everything that originates from the DB or the LLM goes through esc();
 // the only unescaped interpolations are safeJson() (for the client script)
@@ -22,6 +25,7 @@ export interface LinkRow {
   note: string | null;
   status: string; // new | queued | summarized | blocked | dismissed
   error: string | null;
+  summary_id: string | null;
   submitted_at: string | null;
   processed_at: string | null;
   fetch_ms: number | null;
@@ -71,6 +75,7 @@ const STYLE = `
     :root { --accent: #d96b0b; --line: #ddd8ce; --muted: #6a6f7a; --ok: #22633c; --bad: #a33326; }
     body { font-family: system-ui, sans-serif; max-width: 860px; margin: 5vh auto; padding: 0 20px 60px; color: #21252d; line-height: 1.6; }
     h1 { font-size: 22px; margin: 0 0 4px; display: flex; align-items: center; gap: 10px; }
+    h1 .nnn { font-size: 15px; color: var(--accent); }
     p.sub { color: var(--muted); margin: 0 0 20px; font-size: 13.5px; }
     section { border: 1px solid var(--line); border-radius: 6px; padding: 16px 20px; margin-bottom: 16px; background: #fff; }
     section h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin: 0 0 10px; }
@@ -128,10 +133,10 @@ ${body}
 `;
 }
 
-export function renderErrorPage(id: string, message: string): string {
+export function renderErrorPage(subject: string, message: string): string {
   return shell(
-    `Summary ${id} — gen-ai-journal`,
-    `  <h1>Summary ${esc(id)}</h1>
+    `${subject} — gen-ai-journal`,
+    `  <h1>${esc(subject)}</h1>
   <div class="notice">${esc(message)}</div>
   <nav><a href="/admin/pipeline">console</a><a href="/inbox">inbox</a><a href="/admin/logs">events log</a></nav>`,
   );
@@ -186,6 +191,18 @@ function contentHtml(s: SummaryRow): string {
   </section>`;
 }
 
+/** Shown instead of a content section when the link never produced a summary. */
+function noSummaryHtml(link: LinkRow): string {
+  if (link.status === "blocked") {
+    return `<div class="notice"><span class="err" style="font-weight:600">blocked</span> — ${esc(link.error ?? "(no reason recorded)")}<br>
+    Fail-closed: no summary was written, no NNN spent. Retry below, or regenerate locally and push (#168).</div>`;
+  }
+  if (link.status === "dismissed") {
+    return `<div class="notice">Dismissed before a summary was produced — re-open below to queue it.</div>`;
+  }
+  return `<div class="notice">No summary yet — the pipeline ${link.status === "queued" ? "has queued this link" : "will pick this link up shortly"}.</div>`;
+}
+
 function actionButtons(link: LinkRow): string {
   const btn = (label: string, status: string, confirmMsg: string, warn = false) =>
     `<button data-status="${esc(status)}" data-confirm="${esc(confirmMsg)}"${warn ? ' class="warn"' : ""}>${esc(label)}</button>`;
@@ -215,12 +232,7 @@ function actionButtons(link: LinkRow): string {
   return `<div class="actions">${btns.join("")}${hint ? `<span class="hint">${esc(hint)}</span>` : ""}</div>`;
 }
 
-function linkSectionHtml(link: LinkRow | null): string {
-  if (!link) {
-    return `<section><h2>Link</h2>
-    <div class="notice" style="border:none;padding:0;margin:0">No link row references this NNN (deleted, or pushed via the local fallback). Actions unavailable.</div>
-  </section>`;
-  }
+function linkSectionHtml(link: LinkRow): string {
   const label = link.status === "new" ? "generating" : link.status;
   return `<section><h2>Link</h2>
     <table class="kv"><tbody>
@@ -264,8 +276,8 @@ const CLIENT_SCRIPT = `
     }
 
     async function loadLog() {
-      const qs = ["summary_id=" + encodeURIComponent(PAGE.summaryId)];
-      if (PAGE.linkId != null) qs.push("link_id=" + PAGE.linkId);
+      const qs = ["link_id=" + PAGE.linkId];
+      if (PAGE.summaryId != null) qs.push("summary_id=" + encodeURIComponent(PAGE.summaryId));
       const lists = await Promise.all(qs.map(async (q) => {
         const res = await fetch("/api/events?limit=200&" + q, { credentials: "same-origin" });
         return res.ok ? (await res.json()).events : [];
@@ -296,12 +308,16 @@ const CLIENT_SCRIPT = `
     loadLog();
 `;
 
-export function renderSummaryPage(summary: SummaryRow, link: LinkRow | null): string {
-  const page = { summaryId: summary.id, linkId: link ? link.id : null };
-  const body = `  <h1>Summary ${esc(summary.id)} <span class="pill ${esc(summary.status)}">${esc(summary.status)}</span></h1>
-  <p class="sub">${summary.journal_date ? `journal ${esc(summary.journal_date)}` : "workdesk (current cycle)"} · pushed ${fmtTs(summary.pushed_at)} · updated ${fmtTs(summary.updated_at)} · <a href="/api/summaries/${esc(summary.id)}" target="_blank" style="color:var(--accent)">raw JSON</a></p>
+export function renderLinkPage(link: LinkRow, summary: SummaryRow | null): string {
+  const page = { linkId: link.id, summaryId: summary ? summary.id : null };
+  const label = link.status === "new" ? "generating" : link.status;
+  const sub = summary
+    ? `${summary.journal_date ? `journal ${esc(summary.journal_date)}` : "workdesk (current cycle)"} · summary <span class="pill ${esc(summary.status)}">${esc(summary.status)}</span> · pushed ${fmtTs(summary.pushed_at)} · updated ${fmtTs(summary.updated_at)} · <a href="/api/summaries/${esc(summary.id)}" target="_blank" style="color:var(--accent)">raw JSON</a>`
+    : `no NNN allocated${link.status === "blocked" ? " (fail-closed — nothing spent)" : ""} · submitted ${fmtTs(link.submitted_at)}`;
+  const body = `  <h1>L${Number(link.id)} <span class="pill ${esc(link.status)}">${esc(label)}</span>${summary ? ` <span class="nnn">NNN ${esc(summary.id)}</span>` : ""}</h1>
+  <p class="sub">${sub}</p>
 
-${contentHtml(summary)}
+${summary ? contentHtml(summary) : noSummaryHtml(link)}
 
 ${linkSectionHtml(link)}
 
@@ -310,7 +326,7 @@ ${linkSectionHtml(link)}
       <thead><tr><th>time (UTC)</th><th>actor</th><th>event</th><th>detail</th></tr></thead>
       <tbody id="log-rows"></tbody>
     </table></div>
-    <div id="log-empty" hidden style="color:var(--muted);font-size:13px;padding:10px 0 0">No events recorded for this NNN.</div>
+    <div id="log-empty" hidden style="color:var(--muted);font-size:13px;padding:10px 0 0">No events recorded for this link.</div>
   </section>
 
   <nav><a href="/admin/pipeline">console</a><a href="/inbox">inbox</a><a href="/admin/logs">events log</a><a href="/submit">submit</a></nav>
@@ -318,5 +334,5 @@ ${linkSectionHtml(link)}
   <script>
     const PAGE = ${safeJson(page)};
 ${CLIENT_SCRIPT}  </script>`;
-  return shell(`Summary ${summary.id} — gen-ai-journal`, body);
+  return shell(`Link L${Number(link.id)} — gen-ai-journal`, body);
 }

--- a/platform/functions/admin/links/[id].ts
+++ b/platform/functions/admin/links/[id].ts
@@ -1,0 +1,43 @@
+// GET /admin/links/:id (#173) — server-rendered link detail page, keyed by
+// the technical link id so EVERY submitted link — blocked/failed runs that
+// never earned an NNN included — is inspectable: status, content (when
+// summarized), actions (dismiss / re-open / retry / re-summarize), per-run
+// event log. The primary wall is Cloudflare Access on /admin/* (edge 302
+// before this runs); authorize() here is defense-in-depth only.
+
+import { authorize, type Env } from "../../_lib/auth";
+import { renderErrorPage, renderLinkPage, type LinkRow, type SummaryRow } from "../../_lib/summary_page";
+
+function html(markup: string, status = 200): Response {
+  return new Response(markup, { status, headers: { "content-type": "text/html; charset=utf-8" } });
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ request, env, params }) => {
+  const who = await authorize(request, env);
+  if (!who) return new Response("unauthorized", { status: 401 });
+
+  const raw = String(params.id);
+  if (!/^\d+$/.test(raw)) return html(renderErrorPage(`Link ${raw}`, "Invalid id — expected a numeric link id like 7."), 400);
+  const id = Number(raw);
+
+  const link = await env.DB.prepare(
+    "SELECT id, url, note, status, error, summary_id, submitted_at, processed_at, fetch_ms, ai_ms, tokens_in, tokens_out FROM links WHERE id = ?",
+  )
+    .bind(id)
+    .first<LinkRow>();
+  if (!link) return html(renderErrorPage(`Link L${id}`, "No link with this id — it may have been deleted. Events survive at /admin/logs."), 404);
+
+  // The admin detail covers the current cycle: the workdesk row only.
+  // Published rows remain reachable via /api/summaries/:id?journal_date=….
+  let summary: SummaryRow | null = null;
+  if (link.summary_id) {
+    summary =
+      (await env.DB.prepare(
+        "SELECT id, journal_date, url, content, status, pushed_at, updated_at FROM summaries WHERE id = ? AND journal_date IS NULL",
+      )
+        .bind(link.summary_id)
+        .first<SummaryRow>()) ?? null;
+  }
+
+  return html(renderLinkPage(link, summary));
+};

--- a/platform/functions/admin/summaries/[id].ts
+++ b/platform/functions/admin/summaries/[id].ts
@@ -1,11 +1,10 @@
-// GET /admin/summaries/:id (#173) — server-rendered summary detail page.
-// The primary wall is Cloudflare Access on /admin/* (edge 302 before this
-// runs); authorize() here is defense-in-depth only. Raw JSON stays at
-// /api/summaries/:id — this page is the human view: content, link + run
-// metrics, actions (dismiss / re-open / re-summarize), per-run event log.
+// GET /admin/summaries/:NNN (#173) — legacy entry point. The detail page is
+// keyed by link id (/admin/links/:id) so blocked/failed runs are inspectable
+// too; this route resolves the NNN to its latest link and 302s there.
+// Raw JSON stays at /api/summaries/:NNN — untouched.
 
 import { authorize, type Env } from "../../_lib/auth";
-import { renderErrorPage, renderSummaryPage, type LinkRow, type SummaryRow } from "../../_lib/summary_page";
+import { renderErrorPage } from "../../_lib/summary_page";
 
 function html(markup: string, status = 200): Response {
   return new Response(markup, { status, headers: { "content-type": "text/html; charset=utf-8" } });
@@ -16,24 +15,20 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env, params })
   if (!who) return new Response("unauthorized", { status: 401 });
 
   const id = String(params.id);
-  if (!/^\d{3,}$/.test(id)) return html(renderErrorPage(id, "Invalid id — expected a zero-padded NNN like 003."), 400);
+  if (!/^\d{3,}$/.test(id)) return html(renderErrorPage(`Summary ${id}`, "Invalid id — expected a zero-padded NNN like 003."), 400);
 
-  // The admin detail covers the current cycle: the workdesk row only.
-  // Published rows remain reachable via /api/summaries/:id?journal_date=….
-  const summary = await env.DB.prepare(
-    "SELECT id, journal_date, url, content, status, pushed_at, updated_at FROM summaries WHERE id = ? AND journal_date IS NULL",
-  )
+  const link = await env.DB.prepare("SELECT id FROM links WHERE summary_id = ? ORDER BY id DESC LIMIT 1")
     .bind(id)
-    .first<SummaryRow>();
-  if (!summary) {
-    return html(renderErrorPage(id, "No workdesk summary with this NNN. Published rows: /api/summaries/" + id + "?journal_date=YYYY-MM-DD."), 404);
+    .first<{ id: number }>();
+  if (!link) {
+    return html(
+      renderErrorPage(
+        `Summary ${id}`,
+        "No link references this NNN (deleted, or pushed via the local fallback). Raw JSON: /api/summaries/" + id + ".",
+      ),
+      404,
+    );
   }
 
-  const link = await env.DB.prepare(
-    "SELECT id, url, note, status, error, submitted_at, processed_at, fetch_ms, ai_ms, tokens_in, tokens_out FROM links WHERE summary_id = ? ORDER BY id DESC LIMIT 1",
-  )
-    .bind(id)
-    .first<LinkRow>();
-
-  return html(renderSummaryPage(summary, link ?? null));
+  return new Response(null, { status: 302, headers: { location: `/admin/links/${link.id}` } });
 };

--- a/platform/functions/api/links/[id].ts
+++ b/platform/functions/api/links/[id].ts
@@ -25,6 +25,13 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params,
     return error("status must be one of: new, dismissed", 400);
   }
 
+  // Prior status decides which trigger event the log gets (retry vs
+  // re-summarize vs re-open) — RETURNING only yields post-update values.
+  const prior = await env.DB.prepare("SELECT status FROM links WHERE id = ?")
+    .bind(id)
+    .first<{ status: string }>();
+  if (!prior) return error("link not found", 404);
+
   const res = await env.DB.prepare(
     "UPDATE links SET status = ?, error = CASE WHEN ? = 'new' THEN NULL ELSE error END WHERE id = ? RETURNING id, url, status, summary_id",
   )
@@ -69,9 +76,17 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params,
         return json({ ...res, status: "summarized" });
       }
     }
+    // The trigger event names the editor's intent (#178): retry of a blocked
+    // link, re-summarize of a live one, or a plain re-open/requeue.
+    const event =
+      prior.status === "blocked"
+        ? "link.retried"
+        : prior.status === "summarized"
+          ? "link.resummarize_requested"
+          : "link.reopened";
     await logEvent(env.DB, {
       actor: "editor",
-      event: "link.reopened",
+      event,
       linkId: id,
       summaryId: res.summary_id,
       detail: { url: res.url, by: who, requeued: true },

--- a/platform/package.json
+++ b/platform/package.json
@@ -5,7 +5,9 @@
     "check": "tsc --noEmit",
     "test": "vitest run",
     "deploy": "wrangler pages deploy ./public --project-name gen-ai-journal --branch main",
-    "deploy:worker": "cd worker && wrangler deploy"
+    "deploy:worker": "cd worker && wrangler deploy",
+    "deploy:staging": "wrangler pages deploy ./public --project-name gen-ai-journal --branch staging",
+    "deploy:worker:staging": "cd worker && wrangler deploy --env staging"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260620.0",

--- a/platform/public/admin/logs/index.html
+++ b/platform/public/admin/logs/index.html
@@ -14,21 +14,29 @@
     .bar select, .bar button { font-size: 13px; border: 1px solid var(--line); background: #fff; border-radius: 5px; padding: 5px 12px; }
     .bar button { cursor: pointer; }
     .bar .hint { font-size: 12px; color: var(--muted); }
-    table { border-collapse: collapse; width: 100%; font-size: 13px; }
+    /* One line per row (#178): fixed layout + nowrap/ellipsis on the flexible
+       cells; hovering a row shows the full content in the popover. */
+    table { border-collapse: collapse; width: 100%; font-size: 13px; table-layout: fixed; }
     th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); padding: 8px 10px; border-bottom: 2px solid var(--line); white-space: nowrap; }
     td { padding: 7px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
-    td.ts { font-variant-numeric: tabular-nums; white-space: nowrap; color: var(--muted); }
+    td.ts { font-variant-numeric: tabular-nums; white-space: nowrap; overflow: hidden; color: var(--muted); }
     .pill { font-size: 11px; padding: 1px 9px; border-radius: 20px; background: #eee; white-space: nowrap; }
     .pill.editor { background: #e8eef5; color: #33567a; }
     .pill.pipeline { background: #fdf3e4; color: #8a5307; }
     .pill.system { background: #f0f0ee; color: #888; }
+    td.evtd { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .ev { font-family: ui-monospace, monospace; font-size: 12px; white-space: nowrap; }
     .ev.good { color: var(--ok); }
     .ev.bad { color: var(--bad); }
-    .subj { white-space: nowrap; }
+    .ev.step { color: var(--muted); }
+    .subj { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .subj a { color: #1f4e79; }
-    .detail { color: #444; font-size: 12.5px; word-break: break-word; }
+    .detail { color: #444; font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tbl-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 6px; background: #fff; }
+    #log-pop { position: fixed; z-index: 20; max-width: min(560px, 90vw); max-height: 60vh; overflow: auto;
+      background: #21252d; color: #f2efe9; font-family: ui-monospace, monospace; font-size: 12px; line-height: 1.5;
+      padding: 10px 12px; border-radius: 6px; white-space: pre-wrap; word-break: break-word;
+      box-shadow: 0 4px 18px rgba(0,0,0,.3); pointer-events: none; }
     #empty { color: var(--muted); font-size: 14px; padding: 22px 12px; }
     nav { margin-top: 22px; font-size: 13.5px; }
     nav a { color: var(--accent); margin-right: 16px; }
@@ -45,8 +53,14 @@
       <option>link.dismissed</option>
       <option>link.reopened</option>
       <option>summary.created</option>
+      <option>summary.updated</option>
       <option>summary.dismissed</option>
       <option>summary.restored</option>
+      <option>pipeline.run_started</option>
+      <option>pipeline.fetched</option>
+      <option>pipeline.extracted</option>
+      <option>pipeline.model_requested</option>
+      <option>pipeline.model_responded</option>
       <option>pipeline.blocked</option>
       <option>cycle.rolled</option>
     </select>
@@ -55,6 +69,9 @@
       <option value="100">last 100</option>
       <option value="200">last 200</option>
     </select>
+    <label style="display:flex;align-items:center;gap:5px;font-size:13px;cursor:pointer">
+      <input type="checkbox" id="f-steps"> show step events
+    </label>
     <span style="flex:1"></span>
     <span class="hint">auto-refreshes every 30s</span>
     <button id="refresh">↻ refresh</button>
@@ -62,11 +79,13 @@
 
   <div class="tbl-wrap">
     <table>
+      <colgroup><col style="width:158px"><col style="width:88px"><col style="width:196px"><col style="width:112px"><col></colgroup>
       <thead><tr><th>time (UTC)</th><th>actor</th><th>event</th><th>subject</th><th>detail</th></tr></thead>
       <tbody id="rows"></tbody>
     </table>
     <div id="empty" hidden>No events yet.</div>
   </div>
+  <div id="log-pop" hidden></div>
 
   <nav><a href="/admin/pipeline">console</a><a href="/inbox">inbox</a><a href="/submit">submit</a></nav>
 
@@ -94,13 +113,38 @@
       return parts.join(" · ") || "–";
     }
 
+    // Step-level pipeline events (#178) — hidden by default so outcome-level
+    // scanning stays possible; toggle "show step events" (or pick one in the
+    // event filter) to see them.
+    const STEP_EVENTS = new Set(["pipeline.run_started", "pipeline.fetched", "pipeline.extracted", "pipeline.model_requested", "pipeline.model_responded"]);
+
     function evClass(name) {
-      if (name === "summary.created") return "ev good";
+      if (name === "summary.created" || name === "summary.updated") return "ev good";
       if (name === "pipeline.blocked") return "ev bad";
+      if (STEP_EVENTS.has(name)) return "ev step";
       return "ev";
     }
 
     function escapeHtml(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
+
+    // Hover popover (#178): rows are one line (ellipsized); hovering shows the
+    // full event name, timestamp, and pretty-printed detail JSON. Content is
+    // set via textContent only — never innerHTML of user data.
+    const pop = $("log-pop");
+    function popText(e) {
+      let detail = e.detail || "";
+      try { detail = JSON.stringify(JSON.parse(detail), null, 2); } catch { /* leave raw */ }
+      return e.event + "\n" + (e.ts || "") + " · " + e.actor + (detail ? "\n\n" + detail : "");
+    }
+    function placePop(x, y) {
+      pop.style.left = Math.max(8, Math.min(x + 14, window.innerWidth - pop.offsetWidth - 10)) + "px";
+      pop.style.top = Math.max(8, Math.min(y + 14, window.innerHeight - pop.offsetHeight - 10)) + "px";
+    }
+    function attachPop(tr, e) {
+      tr.addEventListener("mouseenter", (m) => { pop.textContent = popText(e); pop.hidden = false; placePop(m.clientX, m.clientY); });
+      tr.addEventListener("mousemove", (m) => placePop(m.clientX, m.clientY));
+      tr.addEventListener("mouseleave", () => { pop.hidden = true; });
+    }
 
     async function load() {
       const p = new URLSearchParams();
@@ -109,23 +153,28 @@
       const res = await fetch("/api/events?" + p, { credentials: "same-origin" });
       if (!res.ok) { $("rows").innerHTML = `<tr><td colspan="5">failed to load (${res.status})</td></tr>`; return; }
       const d = await res.json();
-      $("asof").textContent = d.count + " event" + (d.count === 1 ? "" : "s") + " shown.";
-      $("empty").hidden = d.count !== 0;
+      const showSteps = $("f-steps").checked || Boolean($("f-event").value);
+      const events = showSteps ? d.events : d.events.filter((e) => !STEP_EVENTS.has(e.event));
+      const hidden = d.count - events.length;
+      $("asof").textContent = events.length + " event" + (events.length === 1 ? "" : "s") + " shown" + (hidden > 0 ? " (" + hidden + " step events hidden)." : ".");
+      $("empty").hidden = events.length !== 0;
       $("rows").innerHTML = "";
-      for (const e of d.events) {
+      for (const e of events) {
         const tr = document.createElement("tr");
         tr.innerHTML = `
           <td class="ts">${(e.ts || "").slice(0, 19).replace("T", " ")}</td>
           <td><span class="pill ${e.actor}">${e.actor}</span></td>
-          <td><span class="${evClass(e.event)}">${escapeHtml(e.event)}</span></td>
+          <td class="evtd"><span class="${evClass(e.event)}">${escapeHtml(e.event)}</span></td>
           <td class="subj">${subjectHtml(e)}</td>
           <td class="detail" title="${escapeHtml(e.detail || "")}">${escapeHtml(fmtDetail(e.detail))}</td>`;
+        attachPop(tr, e);
         $("rows").appendChild(tr);
       }
     }
 
     $("f-event").onchange = load;
     $("f-limit").onchange = load;
+    $("f-steps").onchange = load;
     $("refresh").onclick = load;
     load();
     setInterval(load, 30_000);

--- a/platform/public/admin/logs/index.html
+++ b/platform/public/admin/logs/index.html
@@ -52,6 +52,8 @@
       <option>link.submitted</option>
       <option>link.dismissed</option>
       <option>link.reopened</option>
+      <option>link.retried</option>
+      <option>link.resummarize_requested</option>
       <option>summary.created</option>
       <option>summary.updated</option>
       <option>summary.dismissed</option>

--- a/platform/public/admin/logs/index.html
+++ b/platform/public/admin/logs/index.html
@@ -87,12 +87,10 @@
     }
 
     function subjectHtml(e) {
+      // Navigation is keyed by link id (#173) — every run has a detail page.
       const parts = [];
-      if (e.summary_id) {
-        const nnn = encodeURIComponent(e.summary_id);
-        parts.push(`NNN <a href="/admin/summaries/${nnn}" target="_blank"><b>${escapeHtml(e.summary_id)}</b></a>`);
-      }
-      if (e.link_id != null) parts.push(`L${Number(e.link_id)}`);
+      if (e.summary_id) parts.push(`NNN <b>${escapeHtml(e.summary_id)}</b>`);
+      if (e.link_id != null) parts.push(`<a href="/admin/links/${Number(e.link_id)}" target="_blank">L${Number(e.link_id)}</a>`);
       return parts.join(" · ") || "–";
     }
 

--- a/platform/public/admin/pipeline/index.html
+++ b/platform/public/admin/pipeline/index.html
@@ -23,6 +23,7 @@
     th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); padding: 8px 10px; border-bottom: 2px solid var(--line); white-space: nowrap; }
     td { padding: 8px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
     td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
+    td.num a { color: #1f4e79; }
     .pill { font-size: 11px; padding: 1px 9px; border-radius: 20px; background: #eee; white-space: nowrap; }
     .pill.new { background: #e7f2ea; color: var(--ok); }
     .pill.queued { background: #fdf3e4; color: #8a5307; }
@@ -62,7 +63,7 @@
   </div>
 
   <div class="tbl-wrap"><table>
-    <thead><tr><th>NNN</th><th>status</th><th>url / note / error</th><th>run</th><th>tokens</th><th>actions</th></tr></thead>
+    <thead><tr><th>NNN / L</th><th>status</th><th>url / note / error</th><th>run</th><th>tokens</th><th>actions</th></tr></thead>
     <tbody id="rows"></tbody>
   </table></div>
 
@@ -108,11 +109,11 @@
       for (const l of rows) {
         const tr = document.createElement("tr");
         // Read-mostly list (#173): dismiss/re-open/re-summarize live on the
-        // summary detail page; only retry-on-blocked stays here.
+        // link detail page (every row has one); only retry-on-blocked stays here.
         const acts = [];
         if (l.status === "blocked") acts.push(`<button data-a="retry" data-id="${l.id}">retry</button>`);
         tr.innerHTML = `
-          <td class="num">${l.summary_id ? `<a href="/admin/summaries/${encodeURIComponent(l.summary_id)}" target="_blank"><b>${l.summary_id}</b></a>` : "–"}</td>
+          <td class="num">${l.summary_id ? `<b>${l.summary_id}</b> · ` : ""}<a href="/admin/links/${l.id}" target="_blank">L${l.id}</a></td>
           <td><span class="pill ${l.status}">${l.status === "new" ? "generating" : l.status}</span></td>
           <td><div class="u"><a href="${l.url}" target="_blank" rel="noreferrer">${l.url}</a></div>
               ${l.note ? `<div style="font-size:12px;color:var(--muted)">${escapeHtml(l.note)}</div>` : ""}

--- a/platform/public/inbox/index.html
+++ b/platform/public/inbox/index.html
@@ -14,7 +14,8 @@
     .filters button { border: 1px solid var(--line); background: #fff; border-radius: 20px; padding: 4px 14px; font-size: 13px; cursor: pointer; }
     .filters button.on { border-color: var(--accent); color: var(--accent); font-weight: 600; }
     ul { list-style: none; padding: 0; margin: 0; }
-    li { border: 1px solid var(--line); border-radius: 6px; padding: 12px 16px; margin-bottom: 10px; }
+    li { border: 1px solid var(--line); border-radius: 6px; padding: 12px 16px; margin-bottom: 10px; cursor: pointer; transition: border-color .12s, background .12s; }
+    li:hover { border-color: var(--accent); background: #fdfaf6; }
     li .u a { color: #1f4e79; word-break: break-all; text-decoration-thickness: 1px; }
     li .meta { font-size: 12.5px; color: var(--muted); margin-top: 4px; display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
     li .meta .nnn { color: var(--accent); font-weight: 600; }
@@ -80,6 +81,7 @@
       empty.hidden = data.count !== 0;
       for (const l of data.links) {
         const li = document.createElement("li");
+        li.dataset.href = "/admin/links/" + l.id; // whole card → detail page
         const u = document.createElement("div"); u.className = "u";
         const a = document.createElement("a"); a.href = l.url; a.textContent = l.url; a.target = "_blank"; a.rel = "noreferrer";
         u.appendChild(a); li.appendChild(u);
@@ -138,6 +140,19 @@
         rows.appendChild(tr);
       }
     }
+
+    // Whole card navigates to the link detail page; real anchors (the subject
+    // URL, the L<id> token) keep their own targets. Text selection doesn't
+    // navigate; ctrl/cmd-click opens the detail in a new tab.
+    list.addEventListener("click", (e) => {
+      if (e.target.closest("a")) return;
+      const li = e.target.closest("li[data-href]");
+      if (!li) return;
+      const sel = window.getSelection();
+      if (sel && sel.toString()) return;
+      if (e.ctrlKey || e.metaKey) window.open(li.dataset.href, "_blank");
+      else location.href = li.dataset.href;
+    });
 
     document.getElementById("filters").addEventListener("click", (e) => {
       if (e.target.tagName !== "BUTTON") return;

--- a/platform/public/inbox/index.html
+++ b/platform/public/inbox/index.html
@@ -17,7 +17,8 @@
     li { border: 1px solid var(--line); border-radius: 6px; padding: 12px 16px; margin-bottom: 10px; }
     li .u a { color: #1f4e79; word-break: break-all; text-decoration-thickness: 1px; }
     li .meta { font-size: 12.5px; color: var(--muted); margin-top: 4px; display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
-    li .meta a.nnn { color: var(--accent); font-weight: 600; }
+    li .meta .nnn { color: var(--accent); font-weight: 600; }
+    li .meta a.lid { color: #1f4e79; font-weight: 600; }
     .pill { font-size: 11px; padding: 1px 9px; border-radius: 20px; background: #eee; }
     .pill.new { background: #e7f2ea; color: #22633c; }
     .pill.consumed { background: #e8eef5; color: #33567a; }
@@ -88,17 +89,21 @@
         const pill = document.createElement("span"); pill.className = "pill " + l.status; pill.textContent = l.status === "new" ? "generating" : l.status;
         meta.appendChild(pill);
         if (l.summary_id) {
-          // Read-mostly list (#173): actions live on the summary detail page.
-          const nnn = document.createElement("a");
+          const nnn = document.createElement("span");
           nnn.className = "nnn";
-          nnn.href = "/admin/summaries/" + encodeURIComponent(l.summary_id);
           nnn.textContent = "NNN " + l.summary_id;
-          nnn.title = "summary detail: content, actions, run log";
           meta.appendChild(nnn);
         }
-        const t = document.createElement("span"); t.textContent = (l.submitted_at || "").replace("T", " ").slice(0, 16) + "  ·  L" + l.id;
-        t.title = "L" + l.id + " = link id used as subject in /admin/logs";
+        const t = document.createElement("span"); t.textContent = (l.submitted_at || "").replace("T", " ").slice(0, 16);
         meta.appendChild(t);
+        // Read-mostly list (#173): actions live on the link detail page —
+        // every submission has one, blocked/failed runs included.
+        const lid = document.createElement("a");
+        lid.className = "lid";
+        lid.href = "/admin/links/" + l.id;
+        lid.textContent = "L" + l.id;
+        lid.title = "link detail: status, content, actions, run log";
+        meta.appendChild(lid);
         li.appendChild(meta);
         list.appendChild(li);
       }
@@ -120,14 +125,14 @@
         actor.appendChild(pill);
         const ev = document.createElement("td"); ev.className = "ev"; ev.textContent = e.event;
         const subj = document.createElement("td"); subj.className = "subj";
-        if (e.summary_id) {
+        if (e.summary_id) subj.appendChild(document.createTextNode("NNN " + e.summary_id + (e.link_id != null ? " · " : "")));
+        if (e.link_id != null) {
           const a = document.createElement("a");
-          a.href = "/admin/summaries/" + encodeURIComponent(e.summary_id);
-          a.textContent = "NNN " + e.summary_id;
+          a.href = "/admin/links/" + Number(e.link_id);
+          a.textContent = "L" + Number(e.link_id);
           subj.appendChild(a);
-          if (e.link_id != null) subj.appendChild(document.createTextNode(" · L" + Number(e.link_id)));
-        } else {
-          subj.textContent = e.link_id != null ? "L" + Number(e.link_id) : "–";
+        } else if (!e.summary_id) {
+          subj.textContent = "–";
         }
         tr.appendChild(ts); tr.appendChild(actor); tr.appendChild(ev); tr.appendChild(subj);
         rows.appendChild(tr);

--- a/platform/tests/unit.test.ts
+++ b/platform/tests/unit.test.ts
@@ -112,7 +112,7 @@ describe("renderLinkPage (#173 detail page, keyed by link id)", () => {
 
   it("section order: result overview → log → content → link", () => {
     const html = renderLinkPage(link, mkSummary());
-    const result = html.indexOf('<section id="result">');
+    const result = html.indexOf('<section id="result"');
     const log = html.indexOf('<section id="log">');
     const content = html.indexOf("SECRET-BODY-MARKER");
     const linkSec = html.indexOf("<h2>Link</h2>");
@@ -121,6 +121,10 @@ describe("renderLinkPage (#173 detail page, keyed by link id)", () => {
     expect(log).toBeLessThan(content); // log before summary content
     expect(content).toBeLessThan(linkSec); // link section last
     expect(html).toContain("last run"); // run metrics live in the overview now
+    const actions = html.indexOf('class="actions"');
+    expect(actions).toBeGreaterThan(result); // actions live inside the result…
+    expect(actions).toBeLessThan(log); // …section, not down in the link card
+    expect(html).toContain('id="result" class="st-summarized"'); // outcome tint hook
   });
 
   it("dismissed: hides the body but keeps metadata + re-open", () => {

--- a/platform/tests/unit.test.ts
+++ b/platform/tests/unit.test.ts
@@ -110,6 +110,14 @@ describe("renderLinkPage (#173 detail page, keyed by link id)", () => {
     expect(html).toContain('"summaryId":"042"'); // events merged with the NNN history
   });
 
+  it("summarization log section comes before content and link sections", () => {
+    const html = renderLinkPage(link, mkSummary());
+    const log = html.indexOf('<section id="log">');
+    expect(log).toBeGreaterThan(-1);
+    expect(log).toBeLessThan(html.indexOf("SECRET-BODY-MARKER")); // before summary content
+    expect(log).toBeLessThan(html.indexOf("<h2>Link</h2>")); // before link section
+  });
+
   it("dismissed: hides the body but keeps metadata + re-open", () => {
     const html = renderLinkPage({ ...link, status: "dismissed" }, mkSummary({ status: "dismissed" }));
     expect(html).not.toContain("SECRET-BODY-MARKER");

--- a/platform/tests/unit.test.ts
+++ b/platform/tests/unit.test.ts
@@ -136,6 +136,16 @@ describe("renderLinkPage (#173 detail page, keyed by link id)", () => {
     expect(html).toContain("L7");
   });
 
+  it("log rows are one-line with a hover popover (#178)", () => {
+    const html = renderLinkPage(link, mkSummary());
+    expect(html).toContain("table-layout: fixed"); // one-line rows need fixed column widths…
+    expect(html).toContain("text-overflow: ellipsis"); // …and ellipsized flexible cells
+    expect(html).toContain('<div id="log-pop" hidden></div>'); // popover container, hidden by default
+    expect(html).toContain("pop.textContent = popText(e)"); // popover content built with textContent, not innerHTML
+    expect(html).toContain("JSON.stringify(JSON.parse(detail), null, 2)"); // pretty-printed detail JSON in the popover
+    expect(html).toContain("pipeline.run_started"); // step events styled/known by the client script
+  });
+
   it("blocked, no NNN: shows the escaped reason, retry, and no content section", () => {
     const html = renderLinkPage(
       { ...link, status: "blocked", summary_id: null, error: "PDF detected <fail-closed>" },

--- a/platform/tests/unit.test.ts
+++ b/platform/tests/unit.test.ts
@@ -110,12 +110,17 @@ describe("renderLinkPage (#173 detail page, keyed by link id)", () => {
     expect(html).toContain('"summaryId":"042"'); // events merged with the NNN history
   });
 
-  it("summarization log section comes before content and link sections", () => {
+  it("section order: result overview → log → content → link", () => {
     const html = renderLinkPage(link, mkSummary());
+    const result = html.indexOf('<section id="result">');
     const log = html.indexOf('<section id="log">');
-    expect(log).toBeGreaterThan(-1);
-    expect(log).toBeLessThan(html.indexOf("SECRET-BODY-MARKER")); // before summary content
-    expect(log).toBeLessThan(html.indexOf("<h2>Link</h2>")); // before link section
+    const content = html.indexOf("SECRET-BODY-MARKER");
+    const linkSec = html.indexOf("<h2>Link</h2>");
+    expect(result).toBeGreaterThan(-1);
+    expect(result).toBeLessThan(log); // outcome first
+    expect(log).toBeLessThan(content); // log before summary content
+    expect(content).toBeLessThan(linkSec); // link section last
+    expect(html).toContain("last run"); // run metrics live in the overview now
   });
 
   it("dismissed: hides the body but keeps metadata + re-open", () => {

--- a/platform/tests/unit.test.ts
+++ b/platform/tests/unit.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from "vitest";
 import { sanitizeUrl, validateUrl } from "../functions/_lib/util";
 import { blockedStubUrl, displayTitle, inspectSummary, isBlockedStub } from "../functions/_lib/summaries";
-import { renderSummaryPage, type LinkRow, type SummaryRow } from "../functions/_lib/summary_page";
+import { renderLinkPage, type LinkRow, type SummaryRow } from "../functions/_lib/summary_page";
 import { tokensFromUsage } from "../worker/src/core";
 
 describe("sanitizeUrl (mirrors scripts/check_link.py)", () => {
@@ -58,7 +58,7 @@ describe("summary classification", () => {
   });
 });
 
-describe("renderSummaryPage (#173 detail page)", () => {
+describe("renderLinkPage (#173 detail page, keyed by link id)", () => {
   const mkSummary = (over: Partial<SummaryRow> = {}): SummaryRow => ({
     id: "042",
     journal_date: null,
@@ -88,6 +88,7 @@ describe("renderSummaryPage (#173 detail page)", () => {
     note: null,
     status: "summarized",
     error: null,
+    summary_id: "042",
     submitted_at: "2026-07-06T00:00:00Z",
     processed_at: "2026-07-06T00:01:00Z",
     fetch_ms: 500,
@@ -96,33 +97,39 @@ describe("renderSummaryPage (#173 detail page)", () => {
     tokens_out: 800,
   };
 
-  it("renders content with all user text HTML-escaped", () => {
-    const html = renderSummaryPage(mkSummary(), link);
+  it("summarized: renders content with all user text HTML-escaped, shows both ids", () => {
+    const html = renderLinkPage(link, mkSummary());
     expect(html).toContain("SECRET-BODY-MARKER");
     expect(html).toContain("原題: Original &amp; &lt;Title&gt;");
     expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
     expect(html).not.toContain("<script>alert(1)</script>");
     expect(html).toContain("&lt;b&gt;xss&lt;/b&gt;");
     expect(html).toContain("re-summarize"); // summarized link → re-summarize action
-    expect(html).toContain("L7");
+    expect(html).toContain("L7"); // primary key…
+    expect(html).toContain("NNN 042"); // …and the editorial number stays visible
+    expect(html).toContain('"summaryId":"042"'); // events merged with the NNN history
   });
 
-  it("dismissed summaries hide the body but keep metadata + re-open", () => {
-    const html = renderSummaryPage(mkSummary({ status: "dismissed" }), { ...link, status: "dismissed" });
+  it("dismissed: hides the body but keeps metadata + re-open", () => {
+    const html = renderLinkPage({ ...link, status: "dismissed" }, mkSummary({ status: "dismissed" }));
     expect(html).not.toContain("SECRET-BODY-MARKER");
     expect(html).toContain("hidden while dismissed");
     expect(html).toContain("re-open");
     expect(html).not.toContain("re-summarize");
-    expect(html).toContain("Summary 042");
+    expect(html).toContain("L7");
   });
 
-  it("blocked stubs render as escaped raw text; no link row → no actions", () => {
-    const html = renderSummaryPage(
-      mkSummary({ status: "blocked", content: "BLOCKED: paywall <hit>\n\n- URL: https://e.com/a\n" }),
+  it("blocked, no NNN: shows the escaped reason, retry, and no content section", () => {
+    const html = renderLinkPage(
+      { ...link, status: "blocked", summary_id: null, error: "PDF detected <fail-closed>" },
       null,
     );
-    expect(html).toContain("BLOCKED: paywall &lt;hit&gt;");
-    expect(html).toContain("Actions unavailable");
+    expect(html).toContain("PDF detected &lt;fail-closed&gt;");
+    expect(html).not.toContain("<fail-closed>");
+    expect(html).toContain("no NNN allocated");
+    expect(html).not.toContain("Scores"); // no content section rendered
+    expect(html).toContain("retry");
+    expect(html).toContain('"summaryId":null'); // events filtered by link_id only
   });
 });
 

--- a/platform/worker/src/core.ts
+++ b/platform/worker/src/core.ts
@@ -28,9 +28,27 @@ export type SummarizeResult =
   | { ok: true; raw: string; meta: SummarizeMeta }
   | { ok: false; reason: string; meta?: Partial<SummarizeMeta> };
 
+/** Optional per-step event emitter (#178). The DO passes one backed by
+ *  logEvent (adding link_id + the run marker); /eval passes nothing, so eval
+ *  runs persist no events. Fire-and-forget: emitter failures are swallowed
+ *  here so a step event can never fail a run. */
+export type StepEmitter = (event: string, detail: Record<string, unknown>) => void | Promise<void>;
+
 /** The full summarization core — used by the DO (persisting) and /eval (non-persisting). */
-export async function summarizeUrl(env: PipelineEnv, url: string, modelOverride?: string): Promise<SummarizeResult> {
+export async function summarizeUrl(
+  env: PipelineEnv,
+  url: string,
+  modelOverride?: string,
+  onStep?: StepEmitter,
+): Promise<SummarizeResult> {
   const model = modelOverride ?? env.SUMMARIZE_MODEL;
+  const emit = async (event: string, detail: Record<string, unknown>): Promise<void> => {
+    try {
+      await onStep?.(event, detail);
+    } catch {
+      /* step events must never fail or slow the run */
+    }
+  };
 
   // 1. Fetch (fail closed on anything that isn't a readable HTML page)
   const t0 = Date.now();
@@ -53,9 +71,12 @@ export async function summarizeUrl(env: PipelineEnv, url: string, modelOverride?
     return { ok: false, reason: `BLOCKED: unsupported content-type ${ctype.slice(0, 80)}` };
   }
 
-  // 2. Extract main text (streaming, CPU-cheap)
-  const { title, text } = await extractText(res);
+  // 2. Decode (charset-aware) + extract main text (streaming, CPU-cheap)
+  const { html, bytes, charset } = await decodeBody(res);
+  await emit("pipeline.fetched", { status: res.status, ms: Date.now() - t0, bytes, charset });
+  const { title, text } = await extractText(html);
   const fetchMs = Date.now() - t0;
+  await emit("pipeline.extracted", { chars: text.length });
   const minChars = Number(env.MIN_CONTENT_CHARS);
   if (text.length < minChars) {
     return {
@@ -72,6 +93,7 @@ export async function summarizeUrl(env: PipelineEnv, url: string, modelOverride?
   //    neuron budget can't carry the weekly volume at 70B quality);
   //    @cf/* → Workers AI (kept as fallback/eval path).
   const prompt = SUMMARIZE_PROMPT_TEMPLATE.replace("{{url}}", url).replace("{{content}}", `# ${title}\n\n${content}`);
+  await emit("pipeline.model_requested", { model, input_chars: prompt.length });
   const t1 = Date.now();
   let parsed: Record<string, never>;
   let usage: unknown;
@@ -98,6 +120,8 @@ export async function summarizeUrl(env: PipelineEnv, url: string, modelOverride?
     };
   }
   const aiMs = Date.now() - t1;
+  const tk = tokensFromUsage(usage);
+  await emit("pipeline.model_responded", { ms: aiMs, tokens_in: tk.tokensIn, tokens_out: tk.tokensOut });
 
   // 4. Enforce invariants the prompt alone can't guarantee
   const doc = parsed as { metadata?: Record<string, unknown>; content?: Record<string, unknown> };
@@ -126,7 +150,7 @@ export async function summarizeUrl(env: PipelineEnv, url: string, modelOverride?
 /** Decode the body honoring its declared charset (Japanese sites often serve
  *  Shift_JIS / EUC-JP; HTMLRewriter assumes UTF-8, so garbled input must be
  *  re-decoded before parsing — found via itmedia.co.jp in the first e2e run). */
-async function decodeBody(res: Response): Promise<string> {
+async function decodeBody(res: Response): Promise<{ html: string; bytes: number; charset: string }> {
   const buf = await res.arrayBuffer();
   let charset =
     /charset=["']?([\w-]+)/i.exec(res.headers.get("content-type") ?? "")?.[1]?.toLowerCase() ?? null;
@@ -138,9 +162,9 @@ async function decodeBody(res: Response): Promise<string> {
       "utf-8";
   }
   try {
-    return new TextDecoder(charset).decode(buf);
+    return { html: new TextDecoder(charset).decode(buf), bytes: buf.byteLength, charset };
   } catch {
-    return new TextDecoder("utf-8").decode(buf);
+    return { html: new TextDecoder("utf-8").decode(buf), bytes: buf.byteLength, charset: "utf-8" };
   }
 }
 
@@ -193,8 +217,7 @@ function toGeminiSchema(node: Record<string, unknown>): Record<string, unknown> 
   return out;
 }
 
-async function extractText(res: Response): Promise<{ title: string; text: string }> {
-  const html = await decodeBody(res);
+async function extractText(html: string): Promise<{ title: string; text: string }> {
   const chunks: string[] = [];
   let title = "";
   let inTitle = false;

--- a/platform/worker/src/index.ts
+++ b/platform/worker/src/index.ts
@@ -11,7 +11,7 @@
 import { DurableObject } from "cloudflare:workers";
 import { logEvent } from "../../functions/_lib/events";
 import { allocateId, getCycle, writeSummary } from "../../functions/_lib/summaries";
-import { logRun, summarizeUrl, tokensFromUsage, type LinkRow, type SummarizeMeta, type SummarizeResult } from "./core";
+import { logRun, summarizeUrl, tokensFromUsage, type LinkRow, type StepEmitter, type SummarizeMeta, type SummarizeResult } from "./core";
 
 export interface PipelineEnv {
   DB: D1Database;
@@ -47,8 +47,12 @@ export class SummarizerDO extends DurableObject<PipelineEnv> {
     const link = await this.claimNext();
     if (!link) return; // queue drained
 
+    // Run marker (#178): one ISO timestamp per claim, carried in the detail of
+    // every event of this attempt (steps AND the closing blocked/created/
+    // updated), so retries of the same link group into distinct runs.
+    const run = new Date().toISOString();
     try {
-      await this.processLink(link);
+      await this.processLink(link, run);
     } catch (e) {
       // Infra-level failure (D1/AI outage): release the claim and rethrow so
       // the alarm retry (with backoff) picks it up again.
@@ -72,7 +76,7 @@ export class SummarizerDO extends DurableObject<PipelineEnv> {
     ).first<LinkRow>();
   }
 
-  private async block(linkId: number, reason: string, meta?: Partial<SummarizeMeta>): Promise<void> {
+  private async block(linkId: number, reason: string, run: string, meta?: Partial<SummarizeMeta>): Promise<void> {
     await this.recordRun(linkId, meta);
     await this.env.DB.prepare("UPDATE links SET status = 'blocked', error = ? WHERE id = ? AND status = 'queued'")
       .bind(reason.slice(0, 500), linkId)
@@ -82,7 +86,7 @@ export class SummarizerDO extends DurableObject<PipelineEnv> {
       actor: "pipeline",
       event: "pipeline.blocked",
       linkId,
-      detail: { reason: reason.slice(0, 500), model: meta?.model, fetch_ms: meta?.fetchMs, ai_ms: meta?.aiMs, tokens_in: t.tokensIn, tokens_out: t.tokensOut },
+      detail: { run, reason: reason.slice(0, 500), model: meta?.model, fetch_ms: meta?.fetchMs, ai_ms: meta?.aiMs, tokens_in: t.tokensIn, tokens_out: t.tokensOut },
     });
   }
 
@@ -95,27 +99,42 @@ export class SummarizerDO extends DurableObject<PipelineEnv> {
       .run();
   }
 
-  private async processLink(link: LinkRow): Promise<void> {
+  private async processLink(link: LinkRow, run: string): Promise<void> {
+    // Step emitter (#178): persists each pipeline step via logEvent, tagged
+    // with the run marker (and the NNN where the link already has one).
+    // logEvent swallows errors, so a failed INSERT never fails the run.
+    const emit: StepEmitter = (event, detail) =>
+      logEvent(this.env.DB, {
+        actor: "pipeline",
+        event,
+        linkId: link.id,
+        summaryId: link.summary_id ?? null,
+        detail: { run, ...detail },
+      });
+
+    await emit("pipeline.run_started", { url: link.url });
     const cycle = await getCycle(this.env as never);
     if (!cycle) {
-      await this.block(link.id, "no active cycle — POST /api/cycle first");
+      await this.block(link.id, "no active cycle — POST /api/cycle first", run);
       return;
     }
 
-    const out = await summarizeUrl(this.env, link.url);
+    const out = await summarizeUrl(this.env, link.url, undefined, emit);
     logRun(link, out);
     if (!out.ok) {
-      await this.block(link.id, out.reason, out.meta);
+      await this.block(link.id, out.reason, run, out.meta);
       return;
     }
 
     // Reuse the link's existing NNN on re-summarize (retry/re-open of a
     // previously summarized link must never double-spend an ID); otherwise
-    // allocate — IDs are only spent on success.
+    // allocate — IDs are only spent on success. A reused NNN means the write
+    // overwrites an existing summary → close the run as summary.updated.
+    const isOverwrite = link.summary_id != null;
     const id = link.summary_id ?? (await allocateId(this.env as never));
     const result = await writeSummary(this.env as never, { id, content: out.raw });
     if (!result.ok) {
-      await this.block(link.id, `BLOCKED: store rejected — ${result.error}`, out.meta);
+      await this.block(link.id, `BLOCKED: store rejected — ${result.error}`, run, out.meta);
       return;
     }
     await this.recordRun(link.id, out.meta);
@@ -128,10 +147,10 @@ export class SummarizerDO extends DurableObject<PipelineEnv> {
     const t = tokensFromUsage(out.meta.usage);
     await logEvent(this.env.DB, {
       actor: "pipeline",
-      event: "summary.created",
+      event: isOverwrite ? "summary.updated" : "summary.created",
       linkId: link.id,
       summaryId: id,
-      detail: { model: out.meta.model, fetch_ms: out.meta.fetchMs, ai_ms: out.meta.aiMs, tokens_in: t.tokensIn, tokens_out: t.tokensOut },
+      detail: { run, model: out.meta.model, fetch_ms: out.meta.fetchMs, ai_ms: out.meta.aiMs, tokens_in: t.tokensIn, tokens_out: t.tokensOut },
     });
   }
 }

--- a/platform/worker/wrangler.jsonc
+++ b/platform/worker/wrangler.jsonc
@@ -19,5 +19,37 @@
     "bindings": [{ "name": "SUMMARIZER", "class_name": "SummarizerDO" }]
   },
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["SummarizerDO"] }],
-  "observability": { "enabled": true }
+  "observability": { "enabled": true },
+
+  // Staging environment (#177). Deploy: `wrangler deploy --env staging` →
+  // Worker "gen-ai-journal-pipeline-staging" (name auto-suffixed from --env).
+  // Worker environments do NOT inherit binding-type keys (vars, d1_databases,
+  // ai, durable_objects, migrations) — each must be repeated here, else the
+  // staging Worker deploys without them. Only the D1 id differs from prod: the
+  // staging Worker writes to the staging collection, never production D1.
+  "env": {
+    "staging": {
+      "vars": {
+        // Kept identical to prod for a faithful mirror. Flip to a "@cf/*"
+        // Workers AI model to rehearse the pipeline with zero Gemini spend
+        // (model routing is prefix-based — see IMPLEMENTATION_GUIDE §7).
+        "SUMMARIZE_MODEL": "gemini-3-flash-preview",
+        "MIN_CONTENT_CHARS": "200",
+        "MAX_CONTENT_CHARS": "20000"
+      },
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "gen-ai-journal-db-staging",
+          "database_id": "8217e2ac-9d3e-4114-900a-459d5511d4c2"
+        }
+      ],
+      "ai": { "binding": "AI" },
+      "durable_objects": {
+        "bindings": [{ "name": "SUMMARIZER", "class_name": "SummarizerDO" }]
+      },
+      "migrations": [{ "tag": "v1", "new_sqlite_classes": ["SummarizerDO"] }],
+      "observability": { "enabled": true }
+    }
+  }
 }

--- a/platform/wrangler.jsonc
+++ b/platform/wrangler.jsonc
@@ -29,5 +29,48 @@
       "binding": "REBUILD_THROTTLE",
       "id": "1d583e6976fb4e6f84c45e3cdd9ecaec"
     }
-  ]
+  ],
+
+  // Staging front-end = the Pages "preview" environment (#177). Deploy to any
+  // non-production branch: `wrangler pages deploy ./public --branch staging` →
+  // https://staging.gen-ai-journal.pages.dev. Pages picks this block for
+  // preview deployments; the top-level block stays production (--branch main).
+  // Bindings are NOT inherited into preview — repeat them, pointed at staging.
+  // CRITICAL: the DO script_name targets the STAGING pipeline Worker, so the
+  // staging UI enqueues into the staging pipeline (→ staging D1), never prod.
+  // TEAM_DOMAIN/POLICY_AUD stay identical: staging shares the same Zero Trust
+  // team + Access application (add staging.gen-ai-journal.pages.dev to it).
+  "env": {
+    "preview": {
+      "vars": {
+        "TEAM_DOMAIN": "https://gentle-hill-7034.cloudflareaccess.com",
+        // Staging Access application's own AUD (separate app from prod, #177).
+        "POLICY_AUD": "86817f76a5ae56c75fccb76e7825df63866e87b02cf3125bdbd181b2686642b4",
+        "AUTO_SUMMARIZE": "true"
+      },
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "SUMMARIZER",
+            "class_name": "SummarizerDO",
+            "script_name": "gen-ai-journal-pipeline-staging"
+          }
+        ]
+      },
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "gen-ai-journal-db-staging",
+          "database_id": "8217e2ac-9d3e-4114-900a-459d5511d4c2",
+          "migrations_dir": "./migrations"
+        }
+      ],
+      "kv_namespaces": [
+        {
+          "binding": "REBUILD_THROTTLE",
+          "id": "65760529fc7344bca1a5d9491638665c"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Closes #177. Closes #178. Stacked on #175.

Captures the essentials of the Cloudflare summarization platform (epic #155) into a durable knowledge document, organized from what we learned building it across #159–#173 — and lands the Cloudflare-native **staging environment** (#177). The branch has since grown two more slices: the **link-detail-page rework** (#173 follow-up) and **step-level pipeline events with dense log rows** (#178).

## `platform/IMPLEMENTATION_GUIDE.md`
The "why and how it was built" companion to the terse `platform/README.md`:
- Mental model (hub-and-spoke; collection is the hub, producers/consumers swappable)
- Architecture: two separately-deployed Cloudflare units (Pages + companion Worker for the DO) over one shared D1 — and *why* the Worker is separate (Pages can't host DO classes/cron)
- Reproducible infra inventory (account, D1/KV/Pages/Worker ids, Access, secrets)
- Repo layout, the pipeline flow, fail-closed cases
- **The numbering & status semantics** that caused the most back-and-forth: NNN vs `L<id>`, per-cycle allocation, dismiss = reversible content-hidden flag, re-open vs re-summarize
- The #167 model decision (Gemini via API; Workers AI open-weight-only + neuron cap)
- Auth model (why `/api/*` is outside the Access wall)
- Deploy/dev workflow
- **Lessons learned**: esbuild doesn't typecheck, never cap Gemini output, Shift_JIS decode, SQLite NULL-in-PK + CHECK immutability, Access not wrangler-scriptable, audit outlives subject
- Evaluations convention, how-to-extend, roadmap

## CLAUDE.md
New "Cloud Summarization Platform" note under Project Overview pointing to the guide before any `platform/` work.

## Staging environment (#177)
A Cloudflare-native staging mirror of the platform, isolated from production at the data plane (its own D1 — the hub); compute is the Pages `preview` env plus the Worker's `staging` env.

- `worker/wrangler.jsonc` `env.staging` + `wrangler.jsonc` `env.preview` blocks; `deploy:staging` / `deploy:worker:staging` scripts
- **Isolation seam `staging Worker → staging D1`**: the Pages preview DO binding's `script_name` targets `gen-ai-journal-pipeline-staging`, so the staging UI never kicks the prod pipeline
- **Separate Access application** with its own `POLICY_AUD` — the prod app's 5-destination cap forced the split; `TEAM_DOMAIN` stays one team
- Backing resources provisioned via wrangler: D1 `gen-ai-journal-db-staging` (all migrations applied), KV `REBUILD_THROTTLE_staging`, Worker `gen-ai-journal-pipeline-staging`
- Guide updated: §3 staging inventory + isolation seam, §9 dual-DB migrations, §10 the "Pages secrets apply only to new deployments" gotcha

**Verified end-to-end** at https://staging.gen-ai-journal.pages.dev — the Access wall is live on `/submit` `/inbox` `/admin/*` while `/api/*` stays open for machines, and a submitted URL summarized into NNN `001` in ~41s. Smoke-test evidence in the comment below.

## Link detail page rework (#173 follow-up)
The detail page is now **keyed by link id (`/admin/links/<id>`, displayed as `L<n>`)** instead of NNN, so every link — including blocked ones that never earned an NNN — gets a process log page:

- Status-driven **Result overview leads** the page, tinted by outcome; actions (dismiss / re-open / re-summarize / retry) move into the Result section
- **Summarization log is the primary content** — unwrapped from the card look, shown first; summary content is show-on-demand
- Inbox cards click through to the detail page as a whole card

## Step-level pipeline events + dense log rows (#178)
The log previously recorded only run *outcomes* (`summary.created` / `pipeline.blocked`). Now each run leaves a step trail:

- New events along `summarizeUrl()`: run claimed → fetched (status, ms, bytes) → extracted (chars) → model requested/responded (ms, tokens) → summary written; `summary.updated` distinguished from `summary.created` on re-runs
- Emission via an **optional step-emitter callback** threaded into `summarizeUrl()` — the DO passes a `logEvent`-backed emitter; the worker's `/eval` seam passes nothing and stays no-persistence; events remain fire-and-forget (an INSERT failure never fails a run)
- → new triggers named by **editor intent**: `retried` / `resummarize_requested`
- **Every log row renders as one line** (detail page + `/admin/logs`), truncated cells reveal full content — incl. pretty-printed `detail` JSON — in a hover popover
- Unit tests extended; `npm run check` + `npm test` green; README/guide updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
